### PR TITLE
fix: add git workflow rules to CLAUDE.md

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -209,6 +209,16 @@ exec > >(tee -a "$LOG_FILE") 2>&1
 | MENU_LOG_DIR | Log output directory |
 | MENU_DRY_RUN | If set, scripts run in dry-run mode |
 
+## Git Workflow Rules
+
+- **NEVER push directly to main** — all changes must go through a Pull Request
+- Use `/create-pr` to scaffold a new feature branch and open a draft PR
+- Use `/review-tasks` to read code review comments and create todo tasks
+- Use `/approve-pr` to verify review issues are resolved and merge (admin only)
+- Use `/merge-pr` for standard merge workflow (non-admin or when review is already approved)
+- Commit messages should be clear and describe the "why" not just the "what"
+- One feature/fix per branch, one branch per PR
+
 ## Code Style
 
 - Bash scripts: Use shellcheck compliance


### PR DESCRIPTION
## Summary
- Adds explicit git workflow rules to CLAUDE.md
- Documents that all changes must go through PRs (never push directly to main)
- Lists the 4 Claude Code skills as the standard workflow

## Why
The previous commit was accidentally pushed directly to main, bypassing the PR rule.
This adds a guard rail so Claude Code always follows the PR workflow.

## Test Plan
- [ ] Verify CLAUDE.md renders correctly
- [ ] Confirm Claude Code follows the rule in future sessions

Generated with [Claude Code](https://claude.com/claude-code)