### PR TITLE
feat: convert medium + config scripts to use platform.sh

### DIFF
--- a/mainmenu/git/git-setup.sh
+++ b/mainmenu/git/git-setup.sh
@@ -24,31 +24,15 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SCRIPT_NAME="$(basename "${BASH_SOURCE[0]}" .sh)"
 MENU_ROOT="${MENU_ROOT:-$(cd "$SCRIPT_DIR" && while [[ ! -f "menu.py" ]] && [[ "$PWD" != "/" ]]; do cd ..; done; pwd)}"
+source "$MENU_ROOT/.lib/platform.sh"
 
 LOG_DIR="$MENU_ROOT/.docs/logs"
 mkdir -p "$LOG_DIR"
 LOG_FILE="$LOG_DIR/${SCRIPT_NAME}_$(date +%Y%m%d_%H%M%S).log"
 exec > >(tee -a "$LOG_FILE") 2>&1
 
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-BLUE='\033[0;34m'
-CYAN='\033[0;36m'
 MAGENTA='\033[0;35m'
-NC='\033[0m'
 BOLD='\033[1m'
-
-log_info()    { echo -e "${BLUE}[INFO]${NC} $1"; }
-log_success() { echo -e "${GREEN}[SUCCESS]${NC} $1"; }
-log_warn()    { echo -e "${YELLOW}[WARN]${NC} $1"; }
-log_error()   { echo -e "${RED}[ERROR]${NC} $1"; }
-log_step()    { echo -e "${CYAN}[STEP]${NC} $1"; }
-
-mark_installed() {
-    local status="${1:-true}"
-    sed -i "s/^# installed: .*/# installed: $status/" "${BASH_SOURCE[0]}"
-}
 
 install() {
     log_info "Git & GitHub Setup"
@@ -60,8 +44,20 @@ install() {
     if command -v git &>/dev/null; then
         log_success "Git already installed: $(git --version)"
     else
-        sudo apt-get update
-        sudo apt-get install -y git
+        case "$NT_OS" in
+            linux)
+                sudo apt-get update
+                sudo apt-get install -y git
+                ;;
+            macos)
+                # macOS: git comes with Xcode CLI tools, or install via brew
+                if command -v brew &>/dev/null; then
+                    brew install git
+                else
+                    xcode-select --install 2>/dev/null || true
+                fi
+                ;;
+        esac
         log_success "Git installed: $(git --version)"
     fi
     echo ""
@@ -72,11 +68,18 @@ install() {
         log_success "GitHub CLI already installed: $(gh --version | head -1)"
     else
         log_info "Installing GitHub CLI..."
-        curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg 2>/dev/null
-        sudo chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg
-        echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
-        sudo apt-get update
-        sudo apt-get install -y gh
+        case "$NT_OS" in
+            linux)
+                curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg 2>/dev/null
+                sudo chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg
+                echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
+                sudo apt-get update
+                sudo apt-get install -y gh
+                ;;
+            macos)
+                brew install gh
+                ;;
+        esac
         log_success "GitHub CLI installed: $(gh --version | head -1)"
     fi
     echo ""

--- a/mainmenu/git/push-to-repo.sh
+++ b/mainmenu/git/push-to-repo.sh
@@ -26,26 +26,15 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SCRIPT_NAME="$(basename "${BASH_SOURCE[0]}" .sh)"
 MENU_ROOT="${MENU_ROOT:-$(cd "$SCRIPT_DIR" && while [[ ! -f "menu.py" ]] && [[ "$PWD" != "/" ]]; do cd ..; done; pwd)}"
+source "$MENU_ROOT/.lib/platform.sh"
 
 LOG_DIR="$MENU_ROOT/.docs/logs"
 mkdir -p "$LOG_DIR"
 LOG_FILE="$LOG_DIR/${SCRIPT_NAME}_$(date +%Y%m%d_%H%M%S).log"
 exec > >(tee -a "$LOG_FILE") 2>&1
 
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-BLUE='\033[0;34m'
-CYAN='\033[0;36m'
 MAGENTA='\033[0;35m'
-NC='\033[0m'
 BOLD='\033[1m'
-
-log_info()    { echo -e "${BLUE}[INFO]${NC} $1"; }
-log_success() { echo -e "${GREEN}[SUCCESS]${NC} $1"; }
-log_warn()    { echo -e "${YELLOW}[WARN]${NC} $1"; }
-log_error()   { echo -e "${RED}[ERROR]${NC} $1"; }
-log_step()    { echo -e "${CYAN}[STEP]${NC} $1"; }
 
 install() {
     echo ""

--- a/mainmenu/git/reset-credentials.sh
+++ b/mainmenu/git/reset-credentials.sh
@@ -24,30 +24,14 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SCRIPT_NAME="$(basename "${BASH_SOURCE[0]}" .sh)"
 MENU_ROOT="${MENU_ROOT:-$(cd "$SCRIPT_DIR" && while [[ ! -f "menu.py" ]] && [[ "$PWD" != "/" ]]; do cd ..; done; pwd)}"
+source "$MENU_ROOT/.lib/platform.sh"
 
 LOG_DIR="$MENU_ROOT/.docs/logs"
 mkdir -p "$LOG_DIR"
 LOG_FILE="$LOG_DIR/${SCRIPT_NAME}_$(date +%Y%m%d_%H%M%S).log"
 exec > >(tee -a "$LOG_FILE") 2>&1
 
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-BLUE='\033[0;34m'
-CYAN='\033[0;36m'
-NC='\033[0m'
 BOLD='\033[1m'
-
-log_info()    { echo -e "${BLUE}[INFO]${NC} $1"; }
-log_success() { echo -e "${GREEN}[SUCCESS]${NC} $1"; }
-log_warn()    { echo -e "${YELLOW}[WARN]${NC} $1"; }
-log_error()   { echo -e "${RED}[ERROR]${NC} $1"; }
-log_step()    { echo -e "${CYAN}[STEP]${NC} $1"; }
-
-mark_installed() {
-    local status="${1:-true}"
-    sed -i "s/^# installed: .*/# installed: $status/" "${BASH_SOURCE[0]}"
-}
 
 install() {
     echo ""
@@ -126,7 +110,7 @@ install() {
     # Mark git-setup as not installed
     GIT_SETUP="$SCRIPT_DIR/git-setup.sh"
     if [[ -f "$GIT_SETUP" ]]; then
-        sed -i "s/^# installed: .*/# installed: false/" "$GIT_SETUP"
+        nt_sed_i "s/^# installed: .*/# installed: false/" "$GIT_SETUP"
     fi
 
     echo ""

--- a/mainmenu/git/test-connection.sh
+++ b/mainmenu/git/test-connection.sh
@@ -24,25 +24,14 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SCRIPT_NAME="$(basename "${BASH_SOURCE[0]}" .sh)"
 MENU_ROOT="${MENU_ROOT:-$(cd "$SCRIPT_DIR" && while [[ ! -f "menu.py" ]] && [[ "$PWD" != "/" ]]; do cd ..; done; pwd)}"
+source "$MENU_ROOT/.lib/platform.sh"
 
 LOG_DIR="$MENU_ROOT/.docs/logs"
 mkdir -p "$LOG_DIR"
 LOG_FILE="$LOG_DIR/${SCRIPT_NAME}_$(date +%Y%m%d_%H%M%S).log"
 exec > >(tee -a "$LOG_FILE") 2>&1
 
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-BLUE='\033[0;34m'
-CYAN='\033[0;36m'
-NC='\033[0m'
 BOLD='\033[1m'
-
-log_info()    { echo -e "${BLUE}[INFO]${NC} $1"; }
-log_success() { echo -e "${GREEN}[SUCCESS]${NC} $1"; }
-log_warn()    { echo -e "${YELLOW}[WARN]${NC} $1"; }
-log_error()   { echo -e "${RED}[ERROR]${NC} $1"; }
-log_step()    { echo -e "${CYAN}[STEP]${NC} $1"; }
 
 install() {
     echo ""

--- a/mainmenu/llm/claude/claude-code.sh
+++ b/mainmenu/llm/claude/claude-code.sh
@@ -9,43 +9,41 @@
 # tags: "llm, claude, anthropic, ai, cli"
 # ---
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MENU_ROOT="${MENU_ROOT:-$(cd "$SCRIPT_DIR" && while [[ ! -f "menu.py" ]] && [[ "$PWD" != "/" ]]; do cd ..; done; pwd)}"
+source "$MENU_ROOT/.lib/platform.sh"
+
 ACTION="${1:-install}"
 
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-BLUE='\033[0;34m'
-NC='\033[0m'
-
 if [ "$ACTION" = "install" ]; then
-    echo -e "${BLUE}Installing Claude Code CLI...${NC}"
-    
+    log_info "Installing Claude Code CLI..."
+
     # Check if already installed
     if command -v claude &>/dev/null; then
-        echo -e "${GREEN}Claude Code already installed: $(claude --version 2>/dev/null)${NC}"
+        log_success "Claude Code already installed: $(claude --version 2>/dev/null)"
         exit 0
     fi
-    
+
     # Download and run official installer
     curl -fsSL https://claude.ai/install.sh | bash
-    
+
     # Update PATH for current session
     export PATH="$HOME/.local/bin:$PATH"
-    
+
     if command -v claude &>/dev/null; then
-        echo -e "${GREEN}Claude Code installed successfully!${NC}"
+        log_success "Claude Code installed successfully!"
         echo ""
-        echo -e "${BLUE}Quick Start:${NC}"
+        log_info "Quick Start:"
         echo "  claude           # Start interactive mode"
         echo "  claude \"query\"   # One-shot query"
         echo "  claude --help    # Show all options"
     else
-        echo -e "${YELLOW}Claude installed. You may need to restart your terminal or run:${NC}"
+        log_warn "Claude installed. You may need to restart your terminal or run:"
         echo 'export PATH="$HOME/.local/bin:$PATH"'
     fi
 else
-    echo -e "${BLUE}Uninstalling Claude Code CLI...${NC}"
+    log_info "Uninstalling Claude Code CLI..."
     rm -f "$HOME/.local/bin/claude"
     rm -rf "$HOME/.claude"
-    echo -e "${GREEN}Claude Code uninstalled.${NC}"
+    log_success "Claude Code uninstalled."
 fi

--- a/mainmenu/llm/claude/install-skills.sh
+++ b/mainmenu/llm/claude/install-skills.sh
@@ -8,15 +8,9 @@
 # tags: "llm, claude, skills, config"
 # ---
 
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-BLUE='\033[0;34m'
-CYAN='\033[0;36m'
-NC='\033[0m'
-
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 MENU_ROOT="${MENU_ROOT:-$(cd "$SCRIPT_DIR" && while [[ ! -f "menu.py" ]] && [[ "$PWD" != "/" ]]; do cd ..; done; pwd)}"
+source "$MENU_ROOT/.lib/platform.sh"
 SKILLS_SOURCE="$SCRIPT_DIR/.skills"
 CONFIG_FILE="$MENU_ROOT/.configs/menusystem/settings.conf"
 

--- a/mainmenu/llm/cli/claude-cli.sh
+++ b/mainmenu/llm/cli/claude-cli.sh
@@ -24,29 +24,12 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SCRIPT_NAME="$(basename "${BASH_SOURCE[0]}" .sh)"
 MENU_ROOT="${MENU_ROOT:-$(cd "$SCRIPT_DIR" && while [[ ! -f "menu.py" ]] && [[ "$PWD" != "/" ]]; do cd ..; done; pwd)}"
+source "$MENU_ROOT/.lib/platform.sh"
 
 LOG_DIR="$MENU_ROOT/.docs/logs"
 mkdir -p "$LOG_DIR"
 LOG_FILE="$LOG_DIR/${SCRIPT_NAME}_$(date +%Y%m%d_%H%M%S).log"
 exec > >(tee -a "$LOG_FILE") 2>&1
-
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-BLUE='\033[0;34m'
-CYAN='\033[0;36m'
-NC='\033[0m'
-
-log_info()    { echo -e "${BLUE}[INFO]${NC} $1"; }
-log_success() { echo -e "${GREEN}[SUCCESS]${NC} $1"; }
-log_warn()    { echo -e "${YELLOW}[WARN]${NC} $1"; }
-log_error()   { echo -e "${RED}[ERROR]${NC} $1"; }
-log_step()    { echo -e "${CYAN}[STEP]${NC} $1"; }
-
-mark_installed() {
-    local status="${1:-true}"
-    sed -i "s/^# installed: .*/# installed: $status/" "${BASH_SOURCE[0]}"
-}
 
 install() {
     log_info "Installing Claude CLI..."

--- a/mainmenu/llm/cli/codex-cli.sh
+++ b/mainmenu/llm/cli/codex-cli.sh
@@ -26,29 +26,12 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SCRIPT_NAME="$(basename "${BASH_SOURCE[0]}" .sh)"
 MENU_ROOT="${MENU_ROOT:-$(cd "$SCRIPT_DIR" && while [[ ! -f "menu.py" ]] && [[ "$PWD" != "/" ]]; do cd ..; done; pwd)}"
+source "$MENU_ROOT/.lib/platform.sh"
 
 LOG_DIR="$MENU_ROOT/.docs/logs"
 mkdir -p "$LOG_DIR"
 LOG_FILE="$LOG_DIR/${SCRIPT_NAME}_$(date +%Y%m%d_%H%M%S).log"
 exec > >(tee -a "$LOG_FILE") 2>&1
-
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-BLUE='\033[0;34m'
-CYAN='\033[0;36m'
-NC='\033[0m'
-
-log_info()    { echo -e "${BLUE}[INFO]${NC} $1"; }
-log_success() { echo -e "${GREEN}[SUCCESS]${NC} $1"; }
-log_warn()    { echo -e "${YELLOW}[WARN]${NC} $1"; }
-log_error()   { echo -e "${RED}[ERROR]${NC} $1"; }
-log_step()    { echo -e "${CYAN}[STEP]${NC} $1"; }
-
-mark_installed() {
-    local status="${1:-true}"
-    sed -i "s/^# installed: .*/# installed: $status/" "${BASH_SOURCE[0]}"
-}
 
 check_nodejs() {
     if ! command -v node &>/dev/null; then

--- a/mainmenu/llm/cli/gemini-cli.sh
+++ b/mainmenu/llm/cli/gemini-cli.sh
@@ -25,29 +25,12 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SCRIPT_NAME="$(basename "${BASH_SOURCE[0]}" .sh)"
 MENU_ROOT="${MENU_ROOT:-$(cd "$SCRIPT_DIR" && while [[ ! -f "menu.py" ]] && [[ "$PWD" != "/" ]]; do cd ..; done; pwd)}"
+source "$MENU_ROOT/.lib/platform.sh"
 
 LOG_DIR="$MENU_ROOT/.docs/logs"
 mkdir -p "$LOG_DIR"
 LOG_FILE="$LOG_DIR/${SCRIPT_NAME}_$(date +%Y%m%d_%H%M%S).log"
 exec > >(tee -a "$LOG_FILE") 2>&1
-
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-BLUE='\033[0;34m'
-CYAN='\033[0;36m'
-NC='\033[0m'
-
-log_info()    { echo -e "${BLUE}[INFO]${NC} $1"; }
-log_success() { echo -e "${GREEN}[SUCCESS]${NC} $1"; }
-log_warn()    { echo -e "${YELLOW}[WARN]${NC} $1"; }
-log_error()   { echo -e "${RED}[ERROR]${NC} $1"; }
-log_step()    { echo -e "${CYAN}[STEP]${NC} $1"; }
-
-mark_installed() {
-    local status="${1:-true}"
-    sed -i "s/^# installed: .*/# installed: $status/" "${BASH_SOURCE[0]}"
-}
 
 check_nodejs() {
     if ! command -v node &>/dev/null; then

--- a/mainmenu/llm/ide/antigravity.sh
+++ b/mainmenu/llm/ide/antigravity.sh
@@ -26,48 +26,34 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SCRIPT_NAME="$(basename "${BASH_SOURCE[0]}" .sh)"
 MENU_ROOT="${MENU_ROOT:-$(cd "$SCRIPT_DIR" && while [[ ! -f "menu.py" ]] && [[ "$PWD" != "/" ]]; do cd ..; done; pwd)}"
+source "$MENU_ROOT/.lib/platform.sh"
 
 LOG_DIR="$MENU_ROOT/.docs/logs"
 mkdir -p "$LOG_DIR"
 LOG_FILE="$LOG_DIR/${SCRIPT_NAME}_$(date +%Y%m%d_%H%M%S).log"
 exec > >(tee -a "$LOG_FILE") 2>&1
 
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-BLUE='\033[0;34m'
-CYAN='\033[0;36m'
-NC='\033[0m'
-
-log_info()    { echo -e "${BLUE}[INFO]${NC} $1"; }
-log_success() { echo -e "${GREEN}[SUCCESS]${NC} $1"; }
-log_warn()    { echo -e "${YELLOW}[WARN]${NC} $1"; }
-log_error()   { echo -e "${RED}[ERROR]${NC} $1"; }
-log_step()    { echo -e "${CYAN}[STEP]${NC} $1"; }
-
-mark_installed() {
-    local status="${1:-true}"
-    sed -i "s/^# installed: .*/# installed: $status/" "${BASH_SOURCE[0]}"
-}
-
 install() {
     log_info "Installing Google Antigravity IDE..."
     log_info "Log file: $LOG_FILE"
+    require_root
 
     # Check if already installed
     if command -v antigravity &>/dev/null; then
-        log_info "Antigravity already installed: $(dpkg-query -W -f='${Version}' antigravity 2>/dev/null || echo 'version unknown')"
+        log_info "Antigravity already installed"
         mark_installed true
         return 0
     fi
 
-    log_step "Adding Google Antigravity repository..."
+    case "$NT_OS" in
+        linux)
+            log_step "Adding Google Antigravity repository..."
 
-    # Import GPG key
-    curl -fsSL https://us-central1-apt.pkg.dev/doc/repo-signing-key.gpg | gpg --dearmor -o /usr/share/keyrings/google-antigravity.gpg
+            # Import GPG key
+            curl -fsSL https://us-central1-apt.pkg.dev/doc/repo-signing-key.gpg | gpg --dearmor -o /usr/share/keyrings/google-antigravity.gpg
 
-    # Add repository (DEB822 format)
-    cat > /etc/apt/sources.list.d/google-antigravity.sources << 'EOF'
+            # Add repository (DEB822 format)
+            cat > /etc/apt/sources.list.d/google-antigravity.sources << 'EOF'
 Types: deb
 URIs: https://us-central1-apt.pkg.dev/projects/antigravity-auto-updater-dev/
 Suites: antigravity-debian
@@ -75,11 +61,17 @@ Components: main
 Signed-By: /usr/share/keyrings/google-antigravity.gpg
 EOF
 
-    log_step "Updating package list..."
-    apt-get update -qq
+            log_step "Updating package list..."
+            apt-get update -qq
 
-    log_step "Installing antigravity..."
-    apt-get install -y antigravity
+            log_step "Installing antigravity..."
+            apt-get install -y antigravity
+            ;;
+        macos)
+            log_step "Installing Antigravity via Homebrew..."
+            brew install --cask antigravity
+            ;;
+    esac
 
     if command -v antigravity &>/dev/null; then
         log_success "Google Antigravity IDE installed successfully!"
@@ -96,21 +88,24 @@ EOF
 
 uninstall() {
     log_info "Removing Google Antigravity IDE..."
+    require_root
 
-    apt-get remove -y antigravity || true
+    case "$NT_OS" in
+        linux)
+            apt-get remove -y antigravity || true
+            rm -f /etc/apt/sources.list.d/google-antigravity.sources
+            rm -f /usr/share/keyrings/google-antigravity.gpg
+            apt-get update -qq
+            ;;
+        macos)
+            brew uninstall --cask antigravity 2>/dev/null || true
+            ;;
+    esac
 
-    # Remove repository
-    rm -f /etc/apt/sources.list.d/google-antigravity.sources
-    rm -f /usr/share/keyrings/google-antigravity.gpg
-
-    apt-get update -qq
-
-    # Remove config
     rm -rf ~/.config/antigravity
     rm -rf ~/.antigravity
 
     log_success "Google Antigravity IDE removed"
-
     mark_installed false
 }
 

--- a/mainmenu/llm/ide/cursor.sh
+++ b/mainmenu/llm/ide/cursor.sh
@@ -25,33 +25,17 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SCRIPT_NAME="$(basename "${BASH_SOURCE[0]}" .sh)"
 MENU_ROOT="${MENU_ROOT:-$(cd "$SCRIPT_DIR" && while [[ ! -f "menu.py" ]] && [[ "$PWD" != "/" ]]; do cd ..; done; pwd)}"
+source "$MENU_ROOT/.lib/platform.sh"
 
 LOG_DIR="$MENU_ROOT/.docs/logs"
 mkdir -p "$LOG_DIR"
 LOG_FILE="$LOG_DIR/${SCRIPT_NAME}_$(date +%Y%m%d_%H%M%S).log"
 exec > >(tee -a "$LOG_FILE") 2>&1
 
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-BLUE='\033[0;34m'
-CYAN='\033[0;36m'
-NC='\033[0m'
-
-log_info()    { echo -e "${BLUE}[INFO]${NC} $1"; }
-log_success() { echo -e "${GREEN}[SUCCESS]${NC} $1"; }
-log_warn()    { echo -e "${YELLOW}[WARN]${NC} $1"; }
-log_error()   { echo -e "${RED}[ERROR]${NC} $1"; }
-log_step()    { echo -e "${CYAN}[STEP]${NC} $1"; }
-
-mark_installed() {
-    local status="${1:-true}"
-    sed -i "s/^# installed: .*/# installed: $status/" "${BASH_SOURCE[0]}"
-}
-
 install() {
     log_info "Installing Cursor IDE..."
     log_info "Log file: $LOG_FILE"
+    require_root
 
     # Check if already installed
     if command -v cursor &>/dev/null || [[ -f /usr/bin/cursor ]] || [[ -f /opt/Cursor/cursor ]]; then
@@ -60,28 +44,34 @@ install() {
         return 0
     fi
 
-    TEMP_DIR=$(mktemp -d)
-    cd "$TEMP_DIR"
+    case "$NT_OS" in
+        linux)
+            TEMP_DIR=$(mktemp -d)
+            cd "$TEMP_DIR"
 
-    # Detect architecture
-    ARCH=$(uname -m)
-    if [[ "$ARCH" == "x86_64" ]]; then
-        DEB_URL="https://api2.cursor.sh/updates/download/golden/linux-x64-deb/cursor/2.4"
-    elif [[ "$ARCH" == "aarch64" ]]; then
-        DEB_URL="https://api2.cursor.sh/updates/download/golden/linux-arm64-deb/cursor/2.4"
-    else
-        log_error "Unsupported architecture: $ARCH"
-        exit 1
-    fi
+            if [[ "$NT_ARCH" == "x86_64" ]]; then
+                DEB_URL="https://api2.cursor.sh/updates/download/golden/linux-x64-deb/cursor/2.4"
+            elif [[ "$NT_ARCH" == "aarch64" ]]; then
+                DEB_URL="https://api2.cursor.sh/updates/download/golden/linux-arm64-deb/cursor/2.4"
+            else
+                log_error "Unsupported architecture: $NT_ARCH"
+                exit 1
+            fi
 
-    log_step "Downloading Cursor .deb package for $ARCH..."
-    curl -fsSL -o cursor.deb "$DEB_URL"
+            log_step "Downloading Cursor .deb package for $NT_ARCH..."
+            curl -fsSL -o cursor.deb "$DEB_URL"
 
-    log_step "Installing Cursor..."
-    dpkg -i cursor.deb || apt-get install -f -y
+            log_step "Installing Cursor..."
+            dpkg -i cursor.deb || apt-get install -f -y
 
-    cd ~
-    rm -rf "$TEMP_DIR"
+            cd ~
+            rm -rf "$TEMP_DIR"
+            ;;
+        macos)
+            log_step "Installing Cursor via Homebrew..."
+            brew install --cask cursor
+            ;;
+    esac
 
     if command -v cursor &>/dev/null || [[ -f /opt/Cursor/cursor ]]; then
         log_success "Cursor IDE installed successfully!"
@@ -97,13 +87,20 @@ install() {
 
 uninstall() {
     log_info "Removing Cursor IDE..."
+    require_root
 
-    apt-get remove -y cursor 2>/dev/null || dpkg -r cursor 2>/dev/null || true
+    case "$NT_OS" in
+        linux)
+            apt-get remove -y cursor 2>/dev/null || dpkg -r cursor 2>/dev/null || true
+            ;;
+        macos)
+            brew uninstall --cask cursor 2>/dev/null || true
+            ;;
+    esac
     rm -rf ~/.config/Cursor
     rm -rf ~/.cursor
 
     log_success "Cursor IDE removed"
-
     mark_installed false
 }
 

--- a/mainmenu/network/nmap-tools-bundle.sh
+++ b/mainmenu/network/nmap-tools-bundle.sh
@@ -35,6 +35,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SCRIPT_NAME="$(basename "${BASH_SOURCE[0]}" .sh)"
 MENU_ROOT="${MENU_ROOT:-$(cd "$SCRIPT_DIR" && while [[ ! -f "menu.py" ]] && [[ "$PWD" != "/" ]]; do cd ..; done; pwd)}"
+source "$MENU_ROOT/.lib/platform.sh"
 
 # Setup logging
 LOG_DIR="$MENU_ROOT/.docs/logs"
@@ -42,77 +43,19 @@ mkdir -p "$LOG_DIR"
 LOG_FILE="$LOG_DIR/${SCRIPT_NAME}_$(date +%Y%m%d_%H%M%S).log"
 exec > >(tee -a "$LOG_FILE") 2>&1
 
-# Colors
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-BLUE='\033[0;34m'
-CYAN='\033[0;36m'
-NC='\033[0m'
-
-# Logging functions
-log_info()    { echo -e "${BLUE}[INFO]${NC} $1"; }
-log_success() { echo -e "${GREEN}[SUCCESS]${NC} $1"; }
-log_warn()    { echo -e "${YELLOW}[WARN]${NC} $1"; }
-log_error()   { echo -e "${RED}[ERROR]${NC} $1"; }
-log_step()    { echo -e "${CYAN}[STEP]${NC} $1"; }
-
-# Check if running as root when required
-check_root() {
-    if [[ $EUID -ne 0 ]]; then
-        log_error "This script must be run as root (use sudo)"
-        exit 1
-    fi
-}
-
-# Update the installed status in this script's YAML header
-mark_installed() {
-    local status="${1:-true}"
-    sed -i.bak "s/^# installed: .*/# installed: $status/" "${BASH_SOURCE[0]}" && rm -f "${BASH_SOURCE[0]}.bak"
-    log_info "Marked script as installed=$status"
-}
-
-# Detect OS
-detect_os() {
-    local uname_out
-    uname_out="$(uname -s)"
-    case "$uname_out" in
-        Darwin) OS="macos" ;;
-        Linux)
-            if [ -f /etc/os-release ]; then
-                . /etc/os-release
-                if [ "$ID" = "ubuntu" ] || [ "$ID" = "debian" ] || [ "$ID" = "kali" ]; then
-                    OS="debian"
-                    log_info "Detected: $PRETTY_NAME"
-                else
-                    log_error "Unsupported Linux distribution: $ID"
-                    exit 1
-                fi
-            else
-                log_error "Cannot determine Linux distribution"
-                exit 1
-            fi
-            ;;
-        *) log_error "Unsupported OS: $uname_out"; exit 1 ;;
-    esac
-}
-
 # Main installation function
 install() {
     log_info "Starting installation: $SCRIPT_NAME"
     log_info "Log file: $LOG_FILE"
     echo ""
-
-    detect_os
+    require_root
 
     #######################################
     # INSTALLATION LOGIC
     #######################################
 
-    case "$OS" in
-        debian)
-            check_root
-
+    case "$NT_OS" in
+        linux)
             log_step "Step 1: Installing Nmap..."
             apt-get update && apt-get install -y nmap
 
@@ -127,16 +70,6 @@ install() {
             pipx install "git+https://github.com/Sharkeonix/nmap-unleashed.git"
             ;;
         macos)
-            if [[ $EUID -eq 0 ]]; then
-                log_error "This script cannot be run as root on macOS because Homebrew does not support it. Please run without 'sudo'."
-                exit 1
-            fi
-
-            if ! command -v brew &>/dev/null; then
-                log_error "Homebrew is required. Install from https://brew.sh"
-                exit 1
-            fi
-
             log_step "Step 1: Installing Nmap..."
             brew install nmap
 
@@ -175,25 +108,18 @@ install() {
 # Uninstall function
 uninstall() {
     log_info "Starting uninstallation: $SCRIPT_NAME"
-
-    detect_os
+    require_root
 
     #######################################
     # UNINSTALLATION LOGIC
     #######################################
 
-    case "$OS" in
-        debian)
-            check_root
+    case "$NT_OS" in
+        linux)
             pipx uninstall nmap-unleashed 2>/dev/null || true
             apt-get remove -y zenmap nmap xsltproc pipx && apt-get autoremove -y
             ;;
         macos)
-            if [[ $EUID -eq 0 ]]; then
-                log_error "This script cannot be run as root on macOS because Homebrew does not support it. Please run without 'sudo'."
-                exit 1
-            fi
-
             pipx uninstall nmap-unleashed 2>/dev/null || true
             brew uninstall --cask zenmap 2>/dev/null || true
             brew uninstall nmap pipx libxslt 2>/dev/null || true

--- a/mainmenu/postsetup-kali/catppuccin-themes.sh
+++ b/mainmenu/postsetup-kali/catppuccin-themes.sh
@@ -25,29 +25,12 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SCRIPT_NAME="$(basename "${BASH_SOURCE[0]}" .sh)"
 MENU_ROOT="${MENU_ROOT:-$(cd "$SCRIPT_DIR" && while [[ ! -f "menu.py" ]] && [[ "$PWD" != "/" ]]; do cd ..; done; pwd)}"
+source "$MENU_ROOT/.lib/platform.sh"
 
 LOG_DIR="$MENU_ROOT/.docs/logs"
 mkdir -p "$LOG_DIR"
 LOG_FILE="$LOG_DIR/${SCRIPT_NAME}_$(date +%Y%m%d_%H%M%S).log"
 exec > >(tee -a "$LOG_FILE") 2>&1
-
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-BLUE='\033[0;34m'
-CYAN='\033[0;36m'
-NC='\033[0m'
-
-log_info()    { echo -e "${BLUE}[INFO]${NC} $1"; }
-log_success() { echo -e "${GREEN}[SUCCESS]${NC} $1"; }
-log_warn()    { echo -e "${YELLOW}[WARN]${NC} $1"; }
-log_error()   { echo -e "${RED}[ERROR]${NC} $1"; }
-log_step()    { echo -e "${CYAN}[STEP]${NC} $1"; }
-
-mark_installed() {
-    local status="${1:-true}"
-    sed -i "s/^# installed: .*/# installed: $status/" "${BASH_SOURCE[0]}"
-}
 
 install() {
     log_info "Installing Catppuccin Themes..."
@@ -55,32 +38,36 @@ install() {
 
     # Create directories
     mkdir -p ~/.themes
-    mkdir -p ~/.local/share/xfce4/terminal/colorschemes
     mkdir -p ~/.zsh
 
     TEMP_DIR=$(mktemp -d)
     cd "$TEMP_DIR"
 
     #######################################
-    # XFCE4 Terminal themes
+    # XFCE4 Terminal themes (Linux only)
     #######################################
-    log_step "Installing XFCE4 Terminal themes..."
-    curl -sLO https://raw.githubusercontent.com/catppuccin/xfce4-terminal/main/themes/catppuccin-mocha.theme
-    curl -sLO https://raw.githubusercontent.com/catppuccin/xfce4-terminal/main/themes/catppuccin-macchiato.theme
-    curl -sLO https://raw.githubusercontent.com/catppuccin/xfce4-terminal/main/themes/catppuccin-frappe.theme
-    curl -sLO https://raw.githubusercontent.com/catppuccin/xfce4-terminal/main/themes/catppuccin-latte.theme
-    mv catppuccin-*.theme ~/.local/share/xfce4/terminal/colorschemes/
-    log_success "XFCE4 Terminal themes installed"
+    if [[ "$NT_OS" == "linux" ]]; then
+        log_step "Installing XFCE4 Terminal themes..."
+        mkdir -p ~/.local/share/xfce4/terminal/colorschemes
+        curl -sLO https://raw.githubusercontent.com/catppuccin/xfce4-terminal/main/themes/catppuccin-mocha.theme
+        curl -sLO https://raw.githubusercontent.com/catppuccin/xfce4-terminal/main/themes/catppuccin-macchiato.theme
+        curl -sLO https://raw.githubusercontent.com/catppuccin/xfce4-terminal/main/themes/catppuccin-frappe.theme
+        curl -sLO https://raw.githubusercontent.com/catppuccin/xfce4-terminal/main/themes/catppuccin-latte.theme
+        mv catppuccin-*.theme ~/.local/share/xfce4/terminal/colorschemes/
+        log_success "XFCE4 Terminal themes installed"
 
-    #######################################
-    # GTK themes
-    #######################################
-    log_step "Installing GTK themes..."
-    curl -sLO "https://github.com/catppuccin/gtk/releases/download/v1.0.3/catppuccin-mocha-blue-standard+default.zip"
-    curl -sLO "https://github.com/catppuccin/gtk/releases/download/v1.0.3/catppuccin-macchiato-blue-standard+default.zip"
-    unzip -qo "catppuccin-mocha-blue-standard+default.zip" -d ~/.themes/
-    unzip -qo "catppuccin-macchiato-blue-standard+default.zip" -d ~/.themes/
-    log_success "GTK themes installed"
+        #######################################
+        # GTK themes (Linux only)
+        #######################################
+        log_step "Installing GTK themes..."
+        curl -sLO "https://github.com/catppuccin/gtk/releases/download/v1.0.3/catppuccin-mocha-blue-standard+default.zip"
+        curl -sLO "https://github.com/catppuccin/gtk/releases/download/v1.0.3/catppuccin-macchiato-blue-standard+default.zip"
+        unzip -qo "catppuccin-mocha-blue-standard+default.zip" -d ~/.themes/
+        unzip -qo "catppuccin-macchiato-blue-standard+default.zip" -d ~/.themes/
+        log_success "GTK themes installed"
+    else
+        log_info "Skipping XFCE4/GTK themes (Linux only)"
+    fi
 
     #######################################
     # ZSH syntax highlighting themes
@@ -152,8 +139,8 @@ uninstall() {
 
     # Remove from zshrc
     if [[ -f "$HOME/.zshrc" ]]; then
-        sed -i '/catppuccin_mocha-zsh-syntax-highlighting/d' "$HOME/.zshrc"
-        sed -i '/Catppuccin Mocha theme for zsh-syntax-highlighting/d' "$HOME/.zshrc"
+        nt_sed_i '/catppuccin_mocha-zsh-syntax-highlighting/d' "$HOME/.zshrc"
+        nt_sed_i '/Catppuccin Mocha theme for zsh-syntax-highlighting/d' "$HOME/.zshrc"
     fi
 
     # VS Code extension

--- a/mainmenu/postsetup-kali/fix-zsh.sh
+++ b/mainmenu/postsetup-kali/fix-zsh.sh
@@ -22,27 +22,12 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SCRIPT_NAME="$(basename "${BASH_SOURCE[0]}" .sh)"
 MENU_ROOT="${MENU_ROOT:-$(cd "$SCRIPT_DIR" && while [[ ! -f "menu.py" ]] && [[ "$PWD" != "/" ]]; do cd ..; done; pwd)}"
+source "$MENU_ROOT/.lib/platform.sh"
 
 LOG_DIR="$MENU_ROOT/.docs/logs"
 mkdir -p "$LOG_DIR"
 LOG_FILE="$LOG_DIR/${SCRIPT_NAME}_$(date +%Y%m%d_%H%M%S).log"
 exec > >(tee -a "$LOG_FILE") 2>&1
-
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-BLUE='\033[0;34m'
-NC='\033[0m'
-
-log_info()    { echo -e "${BLUE}[INFO]${NC} $1"; }
-log_success() { echo -e "${GREEN}[SUCCESS]${NC} $1"; }
-log_warn()    { echo -e "${YELLOW}[WARN]${NC} $1"; }
-log_error()   { echo -e "${RED}[ERROR]${NC} $1"; }
-
-mark_installed() {
-    local status="${1:-true}"
-    sed -i "s/^# installed: .*/# installed: $status/" "${BASH_SOURCE[0]}"
-}
 
 install() {
     log_info "Fixing ZSH configuration..."
@@ -61,7 +46,7 @@ install() {
 
     # Comment out problematic undercover lines
     if grep -q ": undercover &&" "$ZSHRC"; then
-        sed -i 's/^: undercover && /# : undercover \&\& /' "$ZSHRC"
+        nt_sed_i 's/^: undercover && /# : undercover \&\& /' "$ZSHRC"
         log_success "Commented out undercover lines in .zshrc"
     else
         log_info "No undercover lines found (may already be fixed)"
@@ -86,7 +71,7 @@ uninstall() {
         log_success "Restored from backup: $BACKUP"
     else
         # Just uncomment the lines
-        sed -i 's/^# : undercover \&\& /: undercover \&\& /' "$ZSHRC"
+        nt_sed_i 's/^# : undercover \&\& /: undercover \&\& /' "$ZSHRC"
         log_success "Uncommented undercover lines"
     fi
 

--- a/mainmenu/postsetup-kali/nodejs.sh
+++ b/mainmenu/postsetup-kali/nodejs.sh
@@ -24,33 +24,17 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SCRIPT_NAME="$(basename "${BASH_SOURCE[0]}" .sh)"
 MENU_ROOT="${MENU_ROOT:-$(cd "$SCRIPT_DIR" && while [[ ! -f "menu.py" ]] && [[ "$PWD" != "/" ]]; do cd ..; done; pwd)}"
+source "$MENU_ROOT/.lib/platform.sh"
 
 LOG_DIR="$MENU_ROOT/.docs/logs"
 mkdir -p "$LOG_DIR"
 LOG_FILE="$LOG_DIR/${SCRIPT_NAME}_$(date +%Y%m%d_%H%M%S).log"
 exec > >(tee -a "$LOG_FILE") 2>&1
 
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-BLUE='\033[0;34m'
-CYAN='\033[0;36m'
-NC='\033[0m'
-
-log_info()    { echo -e "${BLUE}[INFO]${NC} $1"; }
-log_success() { echo -e "${GREEN}[SUCCESS]${NC} $1"; }
-log_warn()    { echo -e "${YELLOW}[WARN]${NC} $1"; }
-log_error()   { echo -e "${RED}[ERROR]${NC} $1"; }
-log_step()    { echo -e "${CYAN}[STEP]${NC} $1"; }
-
-mark_installed() {
-    local status="${1:-true}"
-    sed -i "s/^# installed: .*/# installed: $status/" "${BASH_SOURCE[0]}"
-}
-
 install() {
     log_info "Installing Node.js 20 LTS..."
     log_info "Log file: $LOG_FILE"
+    require_root
 
     # Check if Node.js 20 is already installed
     if command -v node &>/dev/null && node -v | grep -q "v20"; then
@@ -59,17 +43,26 @@ install() {
         return 0
     fi
 
-    log_step "Adding NodeSource repository..."
-    curl -fsSL https://deb.nodesource.com/setup_20.x | bash -
+    case "$NT_OS" in
+        linux)
+            log_step "Adding NodeSource repository..."
+            curl -fsSL https://deb.nodesource.com/setup_20.x | bash -
 
-    log_step "Installing nodejs..."
-    apt-get install -y nodejs
+            log_step "Installing nodejs..."
+            apt-get install -y nodejs
 
-    # Verify npm is available
-    if ! command -v npm &>/dev/null; then
-        log_step "Installing npm..."
-        apt-get install -y npm
-    fi
+            # Verify npm is available
+            if ! command -v npm &>/dev/null; then
+                log_step "Installing npm..."
+                apt-get install -y npm
+            fi
+            ;;
+        macos)
+            log_step "Installing Node.js 20 via Homebrew..."
+            brew install node@20
+            brew link node@20 --overwrite 2>/dev/null || true
+            ;;
+    esac
 
     log_success "Node.js installed successfully!"
     echo ""
@@ -82,15 +75,20 @@ install() {
 
 uninstall() {
     log_info "Removing Node.js..."
+    require_root
 
-    apt-get remove -y nodejs npm || true
-    apt-get autoremove -y
-
-    # Remove NodeSource repo
-    rm -f /etc/apt/sources.list.d/nodesource.list
+    case "$NT_OS" in
+        linux)
+            apt-get remove -y nodejs npm || true
+            apt-get autoremove -y
+            rm -f /etc/apt/sources.list.d/nodesource.list
+            ;;
+        macos)
+            brew uninstall node@20 2>/dev/null || brew uninstall node 2>/dev/null || true
+            ;;
+    esac
 
     log_success "Node.js removed"
-
     mark_installed false
 }
 


### PR DESCRIPTION
## Summary
Convert medium-complexity and config/utility scripts to source `.lib/platform.sh`.

This is **PR 3 of 4** in the cross-platform audit initiative.

- Medium scripts: `case $NT_OS` blocks for cursor, antigravity, nodejs, git-setup, codex-cli, gemini-cli, catppuccin-themes
- Config scripts: source platform.sh for mark_installed/nt_sed_i fix
- Refactor nmap-tools-bundle.sh to use shared library

## Test plan
- [ ] Scripts source platform.sh correctly
- [ ] mark_installed works on macOS (no .bak files)
- [ ] `ninjamenu --list` still discovers all scripts

🤖 Generated with [Claude Code](https://claude.com/claude-code)