### PR TITLE
feat: add require_linux guards to Linux-only scripts

### DIFF
--- a/mainmenu/postsetup-kali/proxmox-tools.sh
+++ b/mainmenu/postsetup-kali/proxmox-tools.sh
@@ -23,29 +23,13 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SCRIPT_NAME="$(basename "${BASH_SOURCE[0]}" .sh)"
 MENU_ROOT="${MENU_ROOT:-$(cd "$SCRIPT_DIR" && while [[ ! -f "menu.py" ]] && [[ "$PWD" != "/" ]]; do cd ..; done; pwd)}"
+source "$MENU_ROOT/.lib/platform.sh"
+require_linux "Proxmox Guest Agent requires Linux"
 
 LOG_DIR="$MENU_ROOT/.docs/logs"
 mkdir -p "$LOG_DIR"
 LOG_FILE="$LOG_DIR/${SCRIPT_NAME}_$(date +%Y%m%d_%H%M%S).log"
 exec > >(tee -a "$LOG_FILE") 2>&1
-
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-BLUE='\033[0;34m'
-CYAN='\033[0;36m'
-NC='\033[0m'
-
-log_info()    { echo -e "${BLUE}[INFO]${NC} $1"; }
-log_success() { echo -e "${GREEN}[SUCCESS]${NC} $1"; }
-log_warn()    { echo -e "${YELLOW}[WARN]${NC} $1"; }
-log_error()   { echo -e "${RED}[ERROR]${NC} $1"; }
-log_step()    { echo -e "${CYAN}[STEP]${NC} $1"; }
-
-mark_installed() {
-    local status="${1:-true}"
-    sed -i "s/^# installed: .*/# installed: $status/" "${BASH_SOURCE[0]}"
-}
 
 install() {
     log_info "Installing Proxmox Guest Agent..."

--- a/mainmenu/postsetup-kali/xrdp-xfce.sh
+++ b/mainmenu/postsetup-kali/xrdp-xfce.sh
@@ -25,29 +25,13 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SCRIPT_NAME="$(basename "${BASH_SOURCE[0]}" .sh)"
 MENU_ROOT="${MENU_ROOT:-$(cd "$SCRIPT_DIR" && while [[ ! -f "menu.py" ]] && [[ "$PWD" != "/" ]]; do cd ..; done; pwd)}"
+source "$MENU_ROOT/.lib/platform.sh"
+require_linux "XRDP requires Linux (Kali/Debian)"
 
 LOG_DIR="$MENU_ROOT/.docs/logs"
 mkdir -p "$LOG_DIR"
 LOG_FILE="$LOG_DIR/${SCRIPT_NAME}_$(date +%Y%m%d_%H%M%S).log"
 exec > >(tee -a "$LOG_FILE") 2>&1
-
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-BLUE='\033[0;34m'
-CYAN='\033[0;36m'
-NC='\033[0m'
-
-log_info()    { echo -e "${BLUE}[INFO]${NC} $1"; }
-log_success() { echo -e "${GREEN}[SUCCESS]${NC} $1"; }
-log_warn()    { echo -e "${YELLOW}[WARN]${NC} $1"; }
-log_error()   { echo -e "${RED}[ERROR]${NC} $1"; }
-log_step()    { echo -e "${CYAN}[STEP]${NC} $1"; }
-
-mark_installed() {
-    local status="${1:-true}"
-    sed -i "s/^# installed: .*/# installed: $status/" "${BASH_SOURCE[0]}"
-}
 
 install() {
     log_info "Installing XRDP with XFCE Desktop..."
@@ -88,7 +72,7 @@ STARTWM
     log_step "Configuring X11 wrapper..."
     # Allow Xwrapper non-console access
     if [[ -f /etc/X11/Xwrapper.config ]]; then
-        sed -i 's/^allowed_users=console/allowed_users=anybody/' /etc/X11/Xwrapper.config
+        nt_sed_i 's/^allowed_users=console/allowed_users=anybody/' /etc/X11/Xwrapper.config
     else
         echo "allowed_users=anybody" > /etc/X11/Xwrapper.config
     fi
@@ -102,8 +86,8 @@ STARTWM
     log_step "Applying Proxmox DRI fixes..."
     # Patch XRDP xorg.conf to disable DRI (Proxmox fix)
     if [[ -f /etc/X11/xrdp/xorg.conf ]]; then
-        sed -i 's|Option "DRMDevice" "/dev/dri/renderD128"|Option "DRMDevice" ""|' /etc/X11/xrdp/xorg.conf 2>/dev/null || true
-        sed -i 's|Option "DRI3" "1"|Option "DRI3" "0"|' /etc/X11/xrdp/xorg.conf 2>/dev/null || true
+        nt_sed_i 's|Option "DRMDevice" "/dev/dri/renderD128"|Option "DRMDevice" ""|' /etc/X11/xrdp/xorg.conf 2>/dev/null || true
+        nt_sed_i 's|Option "DRI3" "1"|Option "DRI3" "0"|' /etc/X11/xrdp/xorg.conf 2>/dev/null || true
     fi
 
     log_step "Restarting XRDP services..."

--- a/mainmenu/proxmox/proxmenux.sh
+++ b/mainmenu/proxmox/proxmenux.sh
@@ -24,29 +24,13 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SCRIPT_NAME="$(basename "${BASH_SOURCE[0]}" .sh)"
 MENU_ROOT="${MENU_ROOT:-$(cd "$SCRIPT_DIR" && while [[ ! -f "menu.py" ]] && [[ "$PWD" != "/" ]]; do cd ..; done; pwd)}"
+source "$MENU_ROOT/.lib/platform.sh"
+require_linux "ProxMenux requires Linux (Proxmox VE)"
 
 LOG_DIR="$MENU_ROOT/.docs/logs"
 mkdir -p "$LOG_DIR"
 LOG_FILE="$LOG_DIR/${SCRIPT_NAME}_$(date +%Y%m%d_%H%M%S).log"
 exec > >(tee -a "$LOG_FILE") 2>&1
-
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-BLUE='\033[0;34m'
-CYAN='\033[0;36m'
-NC='\033[0m'
-
-log_info()    { echo -e "${BLUE}[INFO]${NC} $1"; }
-log_success() { echo -e "${GREEN}[SUCCESS]${NC} $1"; }
-log_warn()    { echo -e "${YELLOW}[WARN]${NC} $1"; }
-log_error()   { echo -e "${RED}[ERROR]${NC} $1"; }
-log_step()    { echo -e "${CYAN}[STEP]${NC} $1"; }
-
-mark_installed() {
-    local status="${1:-true}"
-    sed -i "s/^# installed: .*/# installed: $status/" "${BASH_SOURCE[0]}"
-}
 
 install() {
     log_info "Installing ProxMenux..."

--- a/mainmenu/proxmox/proxmox-toolbox.sh
+++ b/mainmenu/proxmox/proxmox-toolbox.sh
@@ -24,29 +24,13 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SCRIPT_NAME="$(basename "${BASH_SOURCE[0]}" .sh)"
 MENU_ROOT="${MENU_ROOT:-$(cd "$SCRIPT_DIR" && while [[ ! -f "menu.py" ]] && [[ "$PWD" != "/" ]]; do cd ..; done; pwd)}"
+source "$MENU_ROOT/.lib/platform.sh"
+require_linux "Proxmox Toolbox requires Linux (Proxmox VE)"
 
 LOG_DIR="$MENU_ROOT/.docs/logs"
 mkdir -p "$LOG_DIR"
 LOG_FILE="$LOG_DIR/${SCRIPT_NAME}_$(date +%Y%m%d_%H%M%S).log"
 exec > >(tee -a "$LOG_FILE") 2>&1
-
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-BLUE='\033[0;34m'
-CYAN='\033[0;36m'
-NC='\033[0m'
-
-log_info()    { echo -e "${BLUE}[INFO]${NC} $1"; }
-log_success() { echo -e "${GREEN}[SUCCESS]${NC} $1"; }
-log_warn()    { echo -e "${YELLOW}[WARN]${NC} $1"; }
-log_error()   { echo -e "${RED}[ERROR]${NC} $1"; }
-log_step()    { echo -e "${CYAN}[STEP]${NC} $1"; }
-
-mark_installed() {
-    local status="${1:-true}"
-    sed -i "s/^# installed: .*/# installed: $status/" "${BASH_SOURCE[0]}"
-}
 
 install() {
     log_info "Installing Proxmox Toolbox..."

--- a/mainmenu/proxmox/pve-helper-scripts.sh
+++ b/mainmenu/proxmox/pve-helper-scripts.sh
@@ -24,29 +24,13 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SCRIPT_NAME="$(basename "${BASH_SOURCE[0]}" .sh)"
 MENU_ROOT="${MENU_ROOT:-$(cd "$SCRIPT_DIR" && while [[ ! -f "menu.py" ]] && [[ "$PWD" != "/" ]]; do cd ..; done; pwd)}"
+source "$MENU_ROOT/.lib/platform.sh"
+require_linux "PVE Helper Scripts require Linux (Proxmox VE)"
 
 LOG_DIR="$MENU_ROOT/.docs/logs"
 mkdir -p "$LOG_DIR"
 LOG_FILE="$LOG_DIR/${SCRIPT_NAME}_$(date +%Y%m%d_%H%M%S).log"
 exec > >(tee -a "$LOG_FILE") 2>&1
-
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-BLUE='\033[0;34m'
-CYAN='\033[0;36m'
-NC='\033[0m'
-
-log_info()    { echo -e "${BLUE}[INFO]${NC} $1"; }
-log_success() { echo -e "${GREEN}[SUCCESS]${NC} $1"; }
-log_warn()    { echo -e "${YELLOW}[WARN]${NC} $1"; }
-log_error()   { echo -e "${RED}[ERROR]${NC} $1"; }
-log_step()    { echo -e "${CYAN}[STEP]${NC} $1"; }
-
-mark_installed() {
-    local status="${1:-true}"
-    sed -i "s/^# installed: .*/# installed: $status/" "${BASH_SOURCE[0]}"
-}
 
 install() {
     log_info "Installing PVE Helper Scripts..."


### PR DESCRIPTION
## Summary
- Add `require_linux` guards to 5 Linux-only scripts (Proxmox, XRDP) so they exit gracefully on macOS with a clear message
- Source `.lib/platform.sh` and remove inline boilerplate (colors, logging, mark_installed)
- Fix `sed -i` calls to use `nt_sed_i` in xrdp-xfce.sh

## Scripts converted
| Script | Guard message |
|--------|--------------|
| xrdp-xfce.sh | XRDP requires Linux (Kali/Debian) |
| proxmox-tools.sh | Proxmox Guest Agent requires Linux |
| proxmenux.sh | ProxMenux requires Linux (Proxmox VE) |
| proxmox-toolbox.sh | Proxmox Toolbox requires Linux (Proxmox VE) |
| pve-helper-scripts.sh | PVE Helper Scripts require Linux (Proxmox VE) |

## Context
Final PR in the 4-part cross-platform audit series:
- PR #4: Foundation (`.lib/platform.sh`)
- PR #5: Simple scripts (monitoring + network)
- PR #6: Medium + config scripts
- **PR #7: Linux-only guards** (this PR)

## Test plan
- [ ] Verify `require_linux` exits gracefully on macOS with log_warn message
- [ ] Verify scripts still install correctly on Linux

🤖 Generated with [Claude Code](https://claude.com/claude-code)