### PR TITLE
feat: add tool script support with binary dependency checking

### DIFF
--- a/.app/menu.py
+++ b/.app/menu.py
@@ -7,6 +7,7 @@ NinjaMenu - Generates menus from folder structure with YAML header parsing.
 import os
 import sys
 import re
+import shutil
 import subprocess
 import argparse
 import platform
@@ -142,6 +143,20 @@ def check_if_installed(info: 'ScriptInfo') -> bool:
     return False
 
 
+def _check_binary_available(binary: str) -> bool:
+    """Check if a required binary is available on PATH."""
+    home = os.path.expanduser("~")
+    extra_paths = [
+        f"{home}/.local/bin",
+        f"{home}/.cargo/bin",
+        f"{home}/.npm-global/bin",
+        "/usr/local/bin",
+        "/opt/homebrew/bin",
+    ]
+    extended_path = ":".join(extra_paths) + ":" + os.environ.get("PATH", "")
+    return shutil.which(binary, path=extended_path) is not None
+
+
 @dataclass
 class ScriptInfo:
     """Parsed script information from YAML header."""
@@ -159,7 +174,9 @@ class ScriptInfo:
     tags: List[str] = field(default_factory=list)
     check_command: str = ""  # Command to check if installed (e.g., "claude --version")
     check_path: str = ""     # Path to check if exists (e.g., "/usr/bin/claude")
-    script_type: str = "install"  # "install" = Install/Uninstall, "config" = Run only
+    script_type: str = "install"  # "install" = Install/Uninstall, "config" = Run only, "tool" = Run with binary check
+    binary: str = ""         # Required binary command for tool scripts (e.g., "nmap")
+    binary_available: bool = True  # Set at runtime after checking binary exists
 
 
 @dataclass
@@ -212,10 +229,14 @@ def parse_yaml_header(script_path: Path) -> Optional[ScriptInfo]:
             tags=data.get('tags', []),
             check_command=data.get('check_command', ''),
             check_path=data.get('check_path', ''),
-            script_type=data.get('type', 'install'),  # "install" or "config"
+            script_type=data.get('type', 'install'),  # "install", "config", or "tool"
+            binary=data.get('binary', ''),
         )
         # Dynamically check if installed
         info.installed = check_if_installed(info)
+        # Check if required binary is available (for tool scripts)
+        if info.binary:
+            info.binary_available = _check_binary_available(info.binary)
         return info
     except Exception as e:
         print(f"Error parsing {script_path}: {e}", file=sys.stderr)
@@ -368,7 +389,13 @@ def gum_menu(directory: Path, breadcrumb: List[str] = None) -> None:
             if item.is_submenu:
                 label = f"{padded}. 📁 {item.name}"
             else:
-                status = "✅" if item.script_info.installed else "⬜"
+                if item.script_info.script_type == "tool":
+                    if item.script_info.binary and not item.script_info.binary_available:
+                        status = "⛔"
+                    else:
+                        status = "▶️ "
+                else:
+                    status = "✅" if item.script_info.installed else "⬜"
                 root = "🔐" if item.script_info.root else "  "
                 label = f"{padded}. {status}{root} {item.name}"
             choices.append(label)
@@ -452,7 +479,33 @@ def gum_script_action(script_info: ScriptInfo) -> None:
 
     while True:
         # Build info display based on script type
-        if script_info.script_type == "config":
+        if script_info.script_type == "tool":
+            binary_status = "✅ found" if script_info.binary_available else "⛔ not found"
+            info_lines = [
+                f"📦 {script_info.name}",
+                f"",
+                f"Description: {script_info.description}",
+                f"Version: {script_info.version}",
+                f"Type: Tool Script",
+                f"Requires: {script_info.binary} ({binary_status})",
+            ]
+            if script_info.binary_available:
+                choices = [
+                    "r. ▶️  Run",
+                    "l. 📋 View Log",
+                    "v. 📄 View Script",
+                    "b. ⬅️  Back"
+                ]
+            else:
+                info_lines.extend([
+                    f"",
+                    f"Install {script_info.binary} first to use this script.",
+                ])
+                choices = [
+                    "v. 📄 View Script",
+                    "b. ⬅️  Back"
+                ]
+        elif script_info.script_type == "config":
             info_lines = [
                 f"📦 {script_info.name}",
                 f"",
@@ -515,7 +568,7 @@ def gum_script_action(script_info: ScriptInfo) -> None:
 
             if selection.startswith("r.") or selection.startswith("i."):
                 run_script(script_info, "install")
-                if script_info.script_type != "config":
+                if script_info.script_type not in ("config", "tool"):
                     updated = parse_yaml_header(script_info.path)
                     if updated:
                         script_info.installed = updated.installed

--- a/.docs/templates/tool_template.sh
+++ b/.docs/templates/tool_template.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+# ---
+# name: "Tool Script Name"
+# description: "Brief description of what this script does"
+# version: "1.0.0"
+# author: "Your Name"
+# type: tool
+# root: false
+# order: 50
+# hidden: false
+# binary: "required-command"
+# tags:
+#   - category
+#   - tool-name
+# ---
+#
+# type: tool — requires a binary to be installed before this script can run.
+# The menu checks the 'binary' field and blocks execution if not found.
+#
+# Folder convention:
+#   mainmenu/education/{category}/{tool}/{technique}/this-script.sh
+#   e.g. mainmenu/education/network/nmap/scanning/quick-scan.sh
+
+#######################################
+# TOOL SCRIPT TEMPLATE
+# Use this for scripts that USE an installed tool
+# (education, demonstration, automation)
+#######################################
+
+set -euo pipefail
+
+# Determine script location and menu root
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT_NAME="$(basename "${BASH_SOURCE[0]}" .sh)"
+MENU_ROOT="${MENU_ROOT:-$(cd "$SCRIPT_DIR" && while [[ ! -f "menu.py" ]] && [[ "$PWD" != "/" ]]; do cd ..; done; pwd)}"
+
+# Source cross-platform library (provides logging, etc.)
+source "$MENU_ROOT/.lib/platform.sh"
+
+# Defence in depth — verify binary is available
+# (The menu already checks this, but this catches direct CLI execution)
+REQUIRED_BINARY="required-command"
+if ! command -v "$REQUIRED_BINARY" &>/dev/null; then
+    log_error "$REQUIRED_BINARY is not installed. Install it first from the menu."
+    exit 1
+fi
+
+# Setup logging
+LOG_DIR="$MENU_ROOT/.docs/logs"
+mkdir -p "$LOG_DIR"
+LOG_FILE="$LOG_DIR/${SCRIPT_NAME}_$(date +%Y%m%d_%H%M%S).log"
+exec > >(tee -a "$LOG_FILE") 2>&1
+
+# Main function
+run() {
+    log_info "Running: $SCRIPT_NAME"
+    log_info "Log file: $LOG_FILE"
+    echo ""
+
+    #######################################
+    # YOUR TOOL SCRIPT LOGIC HERE
+    #######################################
+
+    log_step "Step 1: ..."
+    # e.g., nmap -sn 192.168.1.0/24
+
+    log_step "Step 2: ..."
+    # Your code here
+
+    #######################################
+    # END LOGIC
+    #######################################
+
+    echo ""
+    log_success "Complete: $SCRIPT_NAME"
+}
+
+# Tool scripts only support "run" (called as "install" by menu)
+run

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,6 +99,89 @@ bash mainmenu/category/your-script.sh
 tool-name --version
 ```
 
+## Adding a Tool Script (Education)
+
+Tool scripts are educational/demonstration scripts that **use** an installed tool. They live under `mainmenu/education/` and require a binary to be present before they can run.
+
+### 1. Pick the right folder
+
+Follow the **category > tool > technique** convention:
+
+```
+mainmenu/education/{category}/{tool}/{technique}/your-script.sh
+```
+
+| Level | Rule | Example |
+|-------|------|---------|
+| Category | Match an existing toolbox category | `network`, `monitoring`, `llm` |
+| Tool | Named after the binary | `nmap`, `wireshark`, `htop` |
+| Technique | Group by purpose | `scanning`, `capture`, `analysis` |
+
+Example: `mainmenu/education/network/nmap/scanning/quick-scan.sh`
+
+### 2. Use the YAML header
+
+Tool scripts use `type: tool` and a `binary:` field:
+
+```bash
+#!/bin/bash
+# ---
+# name: "Quick Network Scan"
+# description: "Fast host discovery scan on local subnet"
+# type: tool
+# root: false
+# binary: "nmap"
+# order: 10
+# tags: "network, scanning, nmap"
+# ---
+```
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `type` | Yes | Must be `tool` |
+| `binary` | Yes | Command that must be on PATH (e.g., `"nmap"`) |
+| `name` | Yes | Display name in the menu |
+| `description` | Yes | Short description |
+| `root` | Yes | `true` if needs sudo |
+| `tags` | No | Keywords for search |
+
+The menu checks if `binary` exists. If not, the script shows `⛔` and cannot be run.
+
+### 3. Source platform.sh and check the binary
+
+```bash
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT_NAME="$(basename "${BASH_SOURCE[0]}" .sh)"
+MENU_ROOT="${MENU_ROOT:-$(cd "$SCRIPT_DIR" && while [[ ! -f "menu.py" ]] && [[ "$PWD" != "/" ]]; do cd ..; done; pwd)}"
+source "$MENU_ROOT/.lib/platform.sh"
+
+# Defence in depth — verify binary is available
+REQUIRED_BINARY="nmap"
+if ! command -v "$REQUIRED_BINARY" &>/dev/null; then
+    log_error "$REQUIRED_BINARY is not installed. Install it first from the menu."
+    exit 1
+fi
+```
+
+### 4. Write a run() function
+
+Tool scripts only run — no install/uninstall:
+
+```bash
+run() {
+    log_info "Running: $SCRIPT_NAME"
+    # Your tool logic here
+    nmap -sn 192.168.1.0/24
+    log_success "Scan complete!"
+}
+
+run
+```
+
+### 5. Template
+
+Copy `.docs/templates/tool_template.sh` as a starting point.
+
 ## Reporting Bugs
 
 Open a GitHub issue with:

--- a/README.md
+++ b/README.md
@@ -17,6 +17,13 @@ NinjaMenu is a terminal-based menu system that transforms the chaos of setting u
 05. ✅   ncdu
 ```
 
+Tool scripts show whether their required binary is available:
+
+```
+01. ▶️    Quick Network Scan    (nmap found)
+02. ⛔   Packet Capture        (wireshark not found)
+```
+
 ## The Problem
 
 Every time you set up a new system, it's the same story:
@@ -46,7 +53,8 @@ mainmenu/
 ├── llm/            # Claude Code, LLM CLI tools, IDE extensions
 ├── git/            # Git setup, SSH keys, credential management
 ├── postsetup-kali/ # Themes, shell fixes, desktop environment
-└── proxmox/        # VM management scripts
+├── proxmox/        # VM management scripts
+└── education/      # Tool usage scripts (scanning, analysis, etc.)
 ```
 
 **50+ scripts** ready to go, with more being added regularly.
@@ -112,7 +120,8 @@ That's it. Your script now appears in the menu with install status detection. `p
 | `root` | `true` if needs sudo |
 | `check_command` | How to verify it's installed |
 | `check_path` | Alternative: check if path exists |
-| `type` | `install` or `config` (run-only) |
+| `type` | `install`, `config` (run-only), or `tool` (requires binary) |
+| `binary` | Required command for `tool` scripts (e.g., `"nmap"`) |
 | `order` | Sort position (lower = higher) |
 | `hidden` | `true` to hide from menu |
 

--- a/mainmenu/education/README.md
+++ b/mainmenu/education/README.md
@@ -1,0 +1,46 @@
+# Education Scripts
+
+This section contains **tool scripts** — educational, demonstration, and automation scripts that use tools installed via the NinjaMenu toolbox.
+
+## How It Works
+
+Each script declares a `binary:` field in its YAML header specifying which tool it requires. The menu checks if that binary is installed:
+
+- **▶️** = Binary found, script is ready to run
+- **⛔** = Binary not found, script is blocked (install the tool first)
+
+## Folder Structure
+
+Scripts are organised by **category > tool > technique**:
+
+```
+education/
+├── network/
+│   ├── nmap/
+│   │   ├── scanning/          # Host discovery, port scanning
+│   │   ├── footprinting/      # OS detection, service enumeration
+│   │   └── vulnerability/     # Vulnerability scanning
+│   └── wireshark/
+│       ├── capture/           # Packet capture techniques
+│       └── analysis/          # Traffic analysis
+└── monitoring/
+    └── htop/
+        └── usage/             # Process management examples
+```
+
+### Conventions
+
+| Level | Rule |
+|-------|------|
+| **Category** | Must match an existing toolbox category (`network`, `monitoring`, `llm`, etc.) |
+| **Tool** | Named after the binary (e.g., `nmap`, `wireshark`, `htop`) |
+| **Technique** | Groups scripts by purpose (e.g., `scanning`, `capture`, `analysis`) |
+
+## Adding a Script
+
+1. Copy `.docs/templates/tool_template.sh` into the correct technique folder
+2. Set `binary:` to the required command name (e.g., `"nmap"`)
+3. Set `type: tool` in the YAML header
+4. Write your script logic in the `run()` function
+
+See [CONTRIBUTING.md](../../CONTRIBUTING.md) for full details.


### PR DESCRIPTION
## Summary

- Add `type: tool` and `binary:` YAML header fields to `menu.py` so scripts can declare a required binary dependency
- Menu checks binary availability at display time — shows `▶️` (ready) or `⛔` (missing) and blocks execution when the dependency isn't installed
- Add `mainmenu/education/` section with README documenting the category > tool > technique folder convention
- Add `.docs/templates/tool_template.sh` for creating new tool scripts
- Update `CONTRIBUTING.md` with full "Adding a Tool Script (Education)" guide

## Test plan

- [ ] Verify `menu.py` syntax is valid (`python3 -c "import py_compile; py_compile.compile('.app/menu.py')"`)
- [ ] Create a test tool script with `binary: "nmap"` — confirm menu shows `▶️` if nmap is installed, `⛔` if not
- [ ] Attempt to run a tool script when binary is missing — confirm blocked with message
- [ ] Attempt to run a tool script when binary exists — confirm it runs
- [ ] Verify existing install/config scripts are unaffected (no `binary` field = no change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)