### PR TITLE
Fix wiki images and add docs links to README

### DIFF
--- a/.claude/characters.md
+++ b/.claude/characters.md
@@ -65,7 +65,8 @@ Each character has images prepared for every site background colour:
 | `_14213d` | Prussian Blue | **Main docs site pages** (default) |
 | `_fca311` | Orange | Header areas, callouts |
 | `_e5e5e5` | Alabaster Grey | Footer areas |
-| `_ffffff` | White | **Wiki pages**, GitHub README |
+| `_000000` | Black | **Wiki pages** (dark background) |
+| `_ffffff` | White | GitHub README, light-bg contexts |
 
 Both `.png` and `.webp` formats are available. Use `.png` in markdown (broader compatibility).
 

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
     branches: ["main"]
     paths: ["docs/**"]
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.wiki/FAQ.md
+++ b/.wiki/FAQ.md
@@ -1,4 +1,4 @@
-<img src="https://raw.githubusercontent.com/alistairhendersoninfo/ninja_toolbox/main/docs/assets/images/big_tracey_ninja_ffffff.png" alt="Big Tracey Ninja" width="120" align="right" />
+<img src="https://raw.githubusercontent.com/alistairhendersoninfo/ninja_toolbox/main/docs/assets/images/big_tracey_ninja_000000.png" alt="Big Tracey Ninja" width="120" align="right" />
 
 # Frequently Asked Questions
 

--- a/.wiki/Home.md
+++ b/.wiki/Home.md
@@ -1,4 +1,4 @@
-<img src="https://raw.githubusercontent.com/alistairhendersoninfo/ninja_toolbox/main/docs/assets/images/little_tracey_ninja_ffffff.png" alt="Little Tracey Ninja" width="140" align="right" />
+<img src="https://raw.githubusercontent.com/alistairhendersoninfo/ninja_toolbox/main/docs/assets/images/little_tracey_ninja_000000.png" alt="Little Tracey Ninja" width="140" align="right" />
 
 # Welcome to the NinjaMenu Wiki
 

--- a/.wiki/Tips-and-Tricks.md
+++ b/.wiki/Tips-and-Tricks.md
@@ -1,4 +1,4 @@
-<img src="https://raw.githubusercontent.com/alistairhendersoninfo/ninja_toolbox/main/docs/assets/images/little_tracey_ninja_ffffff.png" alt="Little Tracey Ninja" width="120" align="right" />
+<img src="https://raw.githubusercontent.com/alistairhendersoninfo/ninja_toolbox/main/docs/assets/images/little_tracey_ninja_000000.png" alt="Little Tracey Ninja" width="120" align="right" />
 
 # Tips & Tricks
 

--- a/.wiki/Troubleshooting.md
+++ b/.wiki/Troubleshooting.md
@@ -1,4 +1,4 @@
-<img src="https://raw.githubusercontent.com/alistairhendersoninfo/ninja_toolbox/main/docs/assets/images/big_tracey_ninja_ffffff.png" alt="Big Tracey Ninja" width="120" align="right" />
+<img src="https://raw.githubusercontent.com/alistairhendersoninfo/ninja_toolbox/main/docs/assets/images/big_tracey_ninja_000000.png" alt="Big Tracey Ninja" width="120" align="right" />
 
 # Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -170,7 +170,11 @@ Dependencies installed automatically by `install_menu.sh`:
 
 ## Documentation
 
-Full documentation is available at [alistairhendersoninfo.github.io/ninja_toolbox](https://alistairhendersoninfo.github.io/ninja_toolbox/).
+| Resource | Description |
+|----------|-------------|
+| [Documentation Site](https://alistairhendersoninfo.github.io/ninja_toolbox/) | Getting started, tool reference, architecture |
+| [Wiki](https://github.com/alistairhendersoninfo/ninja_toolbox/wiki) | Community FAQ, troubleshooting, tips & tricks |
+| [Meet the Team](https://alistairhendersoninfo.github.io/ninja_toolbox/meet-the-team/) | The ninja technicians behind NinjaMenu |
 
 ## Contributing
 


### PR DESCRIPTION
## Summary
  - Wiki character images switched from white to black background variants
  - README now links to Documentation Site, Wiki, and Meet the Team page
  - Pages workflow gains workflow_dispatch for manual re-deploys
  - Character guide updated to reflect correct wiki image variant

  ## Test plan
  - [ ] Wiki pages show characters on black background correctly
  - [ ] README documentation table links all resolve
  - [ ] Pages workflow can be triggered manually via Actions tab