### PR TITLE
fix: update character images on network, LLM, and meet-the-team

### DIFF
--- a/.claude/characters.md
+++ b/.claude/characters.md
@@ -14,7 +14,6 @@ The site uses four illustrated characters to add personality and guide users thr
 - `docs/about.md` — About page
 - `docs/contribute.md` — Encouraging contributions (with Big Tracey)
 - `docs/reference/getting-started.md` — Guiding new users
-- `docs/reference/tools/network.md` — Network tools
 - `.wiki/Home.md` — Wiki welcome
 - `.wiki/Tips-and-Tricks.md` — Power-user tips
 
@@ -43,6 +42,8 @@ The site uses four illustrated characters to add personality and guide users thr
 - `docs/reference/architecture.md` — System internals
 - `docs/reference/education/index.md` — Education overview
 - `docs/reference/tools/monitoring.md` — Monitoring tools
+- `docs/reference/tools/network.md` — Network tools
+- `docs/reference/tools/llm.md` — LLM & AI tools (with IT Super Nerd)
 - `docs/reference/tools/git.md` — Git tools
 - `docs/reference/tools/postsetup-kali.md` — Post-setup Kali
 - `docs/reference/tools/proxmox.md` — Proxmox tools
@@ -56,6 +57,7 @@ The site uses four illustrated characters to add personality and guide users thr
 
 **Appears on:**
 - `docs/reference/architecture.md` — Deep technical content (alongside IT Nerd)
+- `docs/reference/tools/llm.md` — LLM & AI tools (with IT Nerd)
 - Education scripts and pages (nmap, network analysis, etc.)
 - `.wiki/` technical pages
 - Any page with in-depth technical walkthroughs
@@ -92,10 +94,11 @@ Both `.png` and `.webp` formats are available. Use `.png` in markdown (broader c
 | Architecture (`architecture.md`) | IT Nerd + IT Super Nerd | Deep technical content |
 | Tools Index (`tools/index.md`) | Big Tracey | Tool overview |
 | Monitoring (`tools/monitoring.md`) | IT Nerd | Infrastructure guru |
-| Network (`tools/network.md`) | Little Tracey | Hands-on network guide |
+| Network (`tools/network.md`) | IT Nerd | Network infrastructure veteran |
 | Git (`tools/git.md`) | IT Nerd | Version control veteran |
 | Post-Setup Kali (`tools/postsetup-kali.md`) | IT Nerd | System configuration expert |
 | Proxmox (`tools/proxmox.md`) | IT Nerd | Infrastructure specialist |
+| LLM & AI (`tools/llm.md`) | IT Nerd + IT Super Nerd | AI tools, old + new school |
 | Education Index (`education/index.md`) | IT Super Nerd | Educational content expert |
 | 404 Page (`404.md`) | Little Tracey | Lighthearted lost page |
 | Wiki Home | Little Tracey | Welcome to wiki |

--- a/docs/meet-the-team.md
+++ b/docs/meet-the-team.md
@@ -12,27 +12,6 @@ Behind every great toolbox, there's a team of highly trained ninja technicians. 
 ---
 
 <div style="display: flex; align-items: flex-start; gap: 1.5rem; margin-bottom: 2rem; flex-wrap: wrap;">
-  <img src="{{ '/assets/images/little_tracey_ninja_14213d.png' | relative_url }}" alt="Little Tracey Ninja" style="width: 180px; border-radius: 12px; flex-shrink: 0;" />
-  <div>
-
-## Little Tracey Ninja
-
-**Role:** Ninja Technician, First Class
-
-Little Tracey has been best friends with Big Tracey for over 30 years — a friendship forged in the ancient fires of Windows 95 setup wizards and cemented by decades of shared trauma from "This program has performed an illegal operation."
-
-Trained by masters in the dark art of IT — the sacred discipline of turning it off and on again — Little Tracey is a GUI warrior through and through. From the revolutionary Start button of Windows 95 to the bewildering tiles of Windows 8, from the Aero glass of Vista to the rounded corners of Windows 11, she has survived every reinvention Microsoft has thrown at the desktop.
-
-**Specialist skills:** Control Panel navigation (all views), right-click context menu mastery, Device Manager troubleshooting, "Have you tried restarting?" counselling, desktop shortcut organisation, and detecting which toolbar the user accidentally installed from a dodgy download.
-
-**Catchphrase:** *"Have you tried turning it off and on again?"*
-
-  </div>
-</div>
-
----
-
-<div style="display: flex; align-items: flex-start; gap: 1.5rem; margin-bottom: 2rem; flex-wrap: wrap;">
   <img src="{{ '/assets/images/big_tracey_ninja_14213d.png' | relative_url }}" alt="Big Tracey Ninja" style="width: 180px; border-radius: 12px; flex-shrink: 0;" />
   <div>
 
@@ -49,6 +28,27 @@ Married to IT Super Nerd — proving that love can blossom over a shared hatred 
 **Specialist skills:** User training and patience (legendary reserves), Group Policy wrangling, Active Directory wizardry, printer troubleshooting (the dark art no one else will touch), and translating tech jargon into plain English.
 
 **Catchphrase:** *"No, you cannot use 'password123'. Not even with a capital P."*
+
+  </div>
+</div>
+
+---
+
+<div style="display: flex; align-items: flex-start; gap: 1.5rem; margin-bottom: 2rem; flex-wrap: wrap;">
+  <img src="{{ '/assets/images/little_tracey_ninja_14213d.png' | relative_url }}" alt="Little Tracey Ninja" style="width: 180px; border-radius: 12px; flex-shrink: 0;" />
+  <div>
+
+## Little Tracey Ninja
+
+**Role:** Ninja Technician, First Class
+
+Little Tracey has been best friends with Big Tracey for over 30 years — a friendship forged in the ancient fires of Windows 95 setup wizards and cemented by decades of shared trauma from "This program has performed an illegal operation."
+
+Trained by masters in the dark art of IT — the sacred discipline of turning it off and on again — Little Tracey is a GUI warrior through and through. From the revolutionary Start button of Windows 95 to the bewildering tiles of Windows 8, from the Aero glass of Vista to the rounded corners of Windows 11, she has survived every reinvention Microsoft has thrown at the desktop.
+
+**Specialist skills:** Control Panel navigation (all views), right-click context menu mastery, Device Manager troubleshooting, "Have you tried restarting?" counselling, desktop shortcut organisation, and detecting which toolbar the user accidentally installed from a dodgy download.
+
+**Catchphrase:** *"Have you tried turning it off and on again?"*
 
   </div>
 </div>

--- a/docs/reference/tools/llm.md
+++ b/docs/reference/tools/llm.md
@@ -6,6 +6,9 @@ grand_parent: Documentation
 nav_order: 3
 ---
 
+<img src="{{ '/assets/images/it_nerd_14213d.png' | relative_url }}" alt="IT Nerd" style="float: right; width: 120px; margin-left: 1rem;" />
+<img src="{{ '/assets/images/it_super_nerd_14213d.png' | relative_url }}" alt="IT Super Nerd" style="float: right; width: 110px; margin-left: 1rem; margin-top: 0.5rem;" />
+
 # LLM & AI Tools
 
 Tools for installing and using Large Language Model command-line interfaces and AI-powered IDEs.

--- a/docs/reference/tools/network.md
+++ b/docs/reference/tools/network.md
@@ -6,7 +6,7 @@ grand_parent: Documentation
 nav_order: 2
 ---
 
-<img src="{{ '/assets/images/little_tracey_ninja_14213d.png' | relative_url }}" alt="Little Tracey Ninja" style="float: right; width: 120px; margin-left: 1rem;" />
+<img src="{{ '/assets/images/it_nerd_14213d.png' | relative_url }}" alt="IT Nerd" style="float: right; width: 120px; margin-left: 1rem;" />
 
 # Network Tools
 


### PR DESCRIPTION
## Summary
- Network page: little_tracey replaced with it_nerd
- LLM & AI page: added it_nerd + it_super_nerd
- Meet the Team: Big Tracey now listed first, Little Tracey second
- characters.md page assignment table updated

## Test plan
- [ ] Network page shows IT Nerd image
- [ ] LLM page shows IT Nerd + IT Super Nerd stacked
- [ ] Meet the Team shows Big Tracey first, Little Tracey second

Generated with [Claude Code](https://claude.com/claude-code)