### PR TITLE
feat: character images, skills, badges, and docs update

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -238,12 +238,33 @@ The site uses four illustrated characters across docs, pages, and wiki. See [`.c
 
 | Character | Role | Pages |
 |-----------|------|-------|
-| **Little Tracey Ninja** | Site worker, day-to-day guides | Homepage, Getting Started, Contribute, Tools, Wiki Home, Tips |
-| **Big Tracey Ninja** | Site worker, day-to-day guides | About, Contact, Docs Hub, Wiki FAQ, Wiki Troubleshooting |
-| **IT Nerd** | Old-school infrastructure guru | Architecture, Education overview, README |
-| **IT Super Nerd** | The brains, deep technical content | Architecture, Education scripts, Wiki technical pages |
+| **Little Tracey Ninja** | Site worker, day-to-day guides | About, Contribute, Getting Started, Wiki Home, Wiki Tips |
+| **Big Tracey Ninja** | Site worker, day-to-day guides | Homepage, Contact, Contribute, Docs Hub, Tools Index, Wiki FAQ, Wiki Troubleshooting |
+| **IT Nerd** | Old-school infrastructure guru | Architecture, Education, Monitoring, Network, LLM, Git, Postsetup-Kali, Proxmox, README |
+| **IT Super Nerd** | The brains, deep technical content | Architecture, LLM, Education scripts, Wiki technical pages |
 
-Image variants exist for each background colour (`_14213d` for docs site, `_ffffff` for wiki/README).
+Image variants exist for each background colour:
+- `_14213d` (Prussian Blue) — docs site pages
+- `_000000` (Black) — wiki pages
+- `_ffffff` (White) — GitHub README
+
+## Brand Colour Palette
+
+| Name | Hex | Role |
+|------|-----|------|
+| Black | `#000000` | Accents, deep backgrounds, wiki bg |
+| Prussian Blue | `#14213d` | Site background |
+| Orange | `#fca311` | Header, links, buttons, accents |
+| Alabaster Grey | `#e5e5e5` | Footer |
+| White | `#ffffff` | All text |
+
+## GitHub Pages & Wiki
+
+- **Pages site:** `docs/` directory, Jekyll with `just-the-docs` remote theme, custom `ninjamenu` colour scheme
+- **Wiki:** `.wiki/` directory (synced to `*.wiki.git` repo separately)
+- **Wiki Guardian:** `.github/scripts/wiki-guardian.sh` — automated spam detection on gollum events
+- **Favicon:** `docs/assets/images/favicon.ico` wired via `docs/_includes/head_custom.html`
+- **Image assets:** `docs/assets/images/` — 60+ variants (5 subjects x 6 backgrounds x 2 formats)
 
 ## Code Style
 

--- a/.claude/TODO.md
+++ b/.claude/TODO.md
@@ -1,49 +1,91 @@
-# TODO - Kali Menu Installer
+# TODO - NinjaMenu
 
-## Phase 1: Core Infrastructure
+## Completed
+
+### Core Infrastructure
 - [x] Create folder structure
 - [x] Create CLAUDE.md documentation
-- [x] Create script template
+- [x] Create script templates
 - [x] Create install_menu.sh
 - [x] Create main menu.py application
-- [ ] Test menu system on fresh install
+- [x] Add cross-platform shared library (`.lib/platform.sh`)
+- [x] Add tool script support with binary dependency checking
 
-## Phase 2: Script Migration
-- [x] Convert kali-setup.sh to modular scripts
-- [x] Create Claude CLI installer
-- [x] Create Cursor IDE installer
-- [x] Create Antigravity installer
-- [x] Create Gemini CLI installer
-- [x] Create Codex installer
-- [x] Create Catppuccin theme installer
-- [x] Create Proxmox tools installer
-- [x] Create ZSH fix script
+### Scripts (79 total)
+- [x] Monitoring suite (13 scripts + install-all)
+- [x] Network suite (18 scripts + install-all + nmap-tools-bundle)
+- [x] LLM & AI tools (Claude, Gemini, Codex, Cursor, Antigravity)
+- [x] Git & GitHub tools (setup, test, reset, push-to-repo)
+- [x] Post-setup Kali (Node.js, ZSH fix, themes, XRDP, Proxmox tools)
+- [x] Proxmox tools (ProxMenux, Toolbox, PVE Helper Scripts)
+- [x] Education: nmap scanning, discovery, evasion, footprinting, output, vulnerability (28 scripts)
+- [x] Education: nmap-unleashed reporting and scanning (5 scripts)
 
-## Phase 3: Documentation
-- [x] Create script template documentation
-- [x] Create user manual
-- [ ] Create technical manual
-- [ ] Add inline help to menu system
+### GitHub Pages Site (docs/)
+- [x] Jekyll site with just-the-docs theme
+- [x] Custom `ninjamenu` colour scheme (Prussian Blue, Orange, Grey, White, Black)
+- [x] Custom SCSS: `_sass/color_schemes/ninjamenu.scss`, `_sass/custom/custom.scss`, `_sass/custom/setup.scss`
+- [x] Homepage with logo in orange block + Big Tracey
+- [x] About, Contact, Contribute pages
+- [x] Reference section: Getting Started, Architecture, Tool Reference (6 categories), Education
+- [x] Meet the Team bio page (all 4 characters)
+- [x] 404 page with Little Tracey
+- [x] Favicon and Apple touch icon
+- [x] OG meta tags and theme-color
 
-## Phase 4: Enhancements
-- [ ] Add search functionality
-- [ ] Add favorites system
+### Wiki (.wiki/)
+- [x] Home, FAQ, Troubleshooting, Tips & Tricks
+- [x] Sidebar, Footer, Script Ideas, Distro Compatibility
+- [x] Character images (using `_000000` variants for dark background)
+
+### GitHub Actions
+- [x] Pages deployment workflow (`.github/workflows/pages.yml`)
+- [x] Wiki Guardian spam detection (`.github/workflows/wiki-guardian.yml` + `.github/scripts/wiki-guardian.sh`)
+- [x] Fix wiki-guardian.sh pipefail crash (grep || true pattern)
+
+### Site Characters
+- [x] 4 characters defined with bios and page assignments
+- [x] 60+ image variants generated (5 subjects x 6 backgrounds x PNG + WebP)
+- [x] Image conversion utility (`docs/assets/convert_image.sh`)
+- [x] Character guide (`.claude/characters.md`)
+
+### Skills
+- [x] `/create-pr` — scaffold new feature branch with draft PR
+- [x] `/merge-pr` — check status and merge PR
+- [x] `/approve-pr` — admin self-review gate
+- [x] `/review-tasks` — read PR review comments, create tasks
+- [x] `/ship-it` — full end-to-end: branch → commit → push → PR → merge
+- [x] `/trigger-guardian` — test Wiki Guardian with clean or spam edit
+
+### README
+- [x] shields.io-style badges (Pages, Wiki, Scripts)
+- [x] Centred logo
+- [x] Documentation links table (Pages, Wiki, Meet the Team)
+
+## In Progress
+
+- [ ] Verify Wiki Guardian works end-to-end (needs a fresh gollum event to trigger)
+- [ ] Push latest character image changes to main (network → it_nerd, LLM → it_nerd+super_nerd, meet-the-team reorder, plus README badges and homepage changes from previous session)
+
+## Backlog
+
+### Enhancements
+- [ ] Add search functionality to menu system
+- [ ] Add favourites system
 - [ ] Add installation history
 - [ ] Add batch installation mode
 - [ ] Add configuration backup/restore
 - [ ] Add update checker for scripts
 
-## Phase 5: Additional Tools
-- [ ] Add Kali tool categories
+### Content
+- [ ] Complete technical manuals for all categories
+- [ ] Add inline help to menu system
+- [ ] Add more education scripts (tcpdump, wireshark, etc.)
 - [ ] Add penetration testing tool installers
 - [ ] Add development environment setups
-- [ ] Add virtualization tool installers
 
-## Bugs
-- None reported yet
-
-## Ideas
-- Web-based interface option
-- Remote installation support
-- Script marketplace/repository
-- Auto-update mechanism
+### Ideas
+- [ ] Web-based interface option
+- [ ] Remote installation support
+- [ ] Script marketplace/repository
+- [ ] Auto-update mechanism

--- a/README.md
+++ b/README.md
@@ -1,4 +1,12 @@
+<p align="center">
+  <img src="docs/assets/images/toolbox_ninja_logo_000000.png" alt="NinjaMenu Logo" width="180" />
+</p>
+
 # NinjaMenu
+
+[![Pages](https://img.shields.io/badge/Pages_Site-17_pages-fca311?style=for-the-badge&logo=github&logoColor=white)](https://alistairhendersoninfo.github.io/ninja_toolbox/)
+[![Wiki](https://img.shields.io/badge/Wiki-9_pages-14213d?style=for-the-badge&logo=github&logoColor=white)](https://github.com/alistairhendersoninfo/ninja_toolbox/wiki)
+[![Scripts](https://img.shields.io/badge/Scripts-75+-e5e5e5?style=for-the-badge&logo=gnubash&logoColor=000000)](https://alistairhendersoninfo.github.io/ninja_toolbox/reference/tools/)
 
 **Stop hunting for install commands. Start getting things done.**
 


### PR DESCRIPTION
## Summary
- Reassign character images across all docs pages to match agreed layout
- Add favicon and apple-touch-icon to site head
- Add shields.io badges and centred logo to README
- Create /ship-it and /trigger-guardian skills
- Update CLAUDE.md with full skills table, colour palette, Pages/Wiki docs
- Rewrite TODO.md to reflect all completed work
- Update characters.md page assignment table

## Test plan
- [ ] Each docs page shows the correct character image
- [ ] Favicon appears in browser tab
- [ ] README badges render on GitHub
- [ ] Skills are listed in CLAUDE.md

Generated with [Claude Code](https://claude.com/claude-code)