### PR TITLE
fix: pr-status skill — add issues + fix checks field

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -231,7 +231,7 @@ exec > >(tee -a "$LOG_FILE") 2>&1
 | Approve PR | `/approve-pr [pr-number]` | Admin self-review gate before merge |
 | Review Tasks | `/review-tasks [pr-number]` | Read PR review comments and create todo tasks |
 | Trigger Guardian | `/trigger-guardian [spam]` | Test Wiki Guardian with a clean or spam wiki edit |
-| PR Status | `/pr-status [pr-number]` | Show open PRs summary or detailed view of a specific PR |
+| PR Status | `/pr-status [number \| issue number]` | Show open PRs and issues, or detail view of a specific PR/issue |
 
 ## Site Characters
 

--- a/.claude/skills/pr-status/SKILL.md
+++ b/.claude/skills/pr-status/SKILL.md
@@ -1,33 +1,39 @@
 ---
 name: pr-status
-description: "Show open PRs — summary table or detailed view of a specific PR"
-argument-hint: "[pr-number]"
+description: "Show open PRs and issues — summary or detailed view"
+argument-hint: "[pr-number | issue-number]"
 disable-model-invocation: true
 allowed-tools: Bash, Read
 ---
 
 # PR Status
 
-Show the status of open pull requests. Two modes:
+Show the status of open pull requests and issues. Three modes:
 
-- **Summary** (no arguments): Table of all open PRs with key info
-- **Detail** (PR number provided): Full breakdown of a specific PR
+- **Summary** (no arguments): Table of all open PRs + table of all open issues
+- **PR Detail** (PR number): Full breakdown of a specific PR
+- **Issue Detail** (`issue <number>`): Full breakdown of a specific issue
 
 **Usage:**
-- `/pr-status` — show all open PRs in a summary table
+- `/pr-status` — show all open PRs and issues
 - `/pr-status 23` — show detailed view of PR #23
+- `/pr-status issue 20` — show detailed view of issue #20
 
 ## Execution
 
 ### If `$ARGUMENTS` is empty — Summary Mode
 
-Run the following command to get all open PRs:
+Run these two commands:
 
 ```bash
-gh pr list --state open --json number,title,headRefName,author,createdAt,labels,reviewDecision,checks,additions,deletions,changedFiles --limit 50
+gh pr list --state open --json number,title,headRefName,author,createdAt,labels,reviewDecision,statusCheckRollup,additions,deletions,changedFiles --limit 50
 ```
 
-Present the results as a markdown table with these columns:
+```bash
+gh issue list --state open --json number,title,labels,author,createdAt,updatedAt --limit 50
+```
+
+**Present open PRs** as a markdown table:
 
 | # | Title | Branch | Author | Created | Files | +/- | Reviews | Checks |
 |---|-------|--------|--------|---------|-------|-----|---------|--------|
@@ -35,19 +41,29 @@ Present the results as a markdown table with these columns:
 - **Files**: `changedFiles` count
 - **+/-**: `+additions/-deletions`
 - **Reviews**: `reviewDecision` (APPROVED, CHANGES_REQUESTED, REVIEW_REQUIRED, or blank)
-- **Checks**: Summarise as PASS/FAIL/PENDING based on check conclusions
+- **Checks**: Summarise `statusCheckRollup` as PASS/FAIL/PENDING based on check conclusions
 - **Created**: Show as relative time (e.g., "2h ago", "3d ago")
 
 If there are no open PRs, say: "No open PRs — everything is merged."
 
-Also show a count summary at the bottom: `X open PR(s)`
+**Present open issues** as a markdown table:
 
-### If `$ARGUMENTS` contains a PR number — Detail Mode
+| # | Title | Labels | Author | Created |
+|---|-------|--------|--------|---------|
 
-Run these commands to gather full details:
+- **Labels**: comma-separated label names, or blank
+- **Created**: Show as relative time
+
+If there are no open issues, say: "No open issues."
+
+Show a count summary at the bottom: `X open PR(s), Y open issue(s)`
+
+### If `$ARGUMENTS` contains just a number — PR Detail Mode
+
+Run this command:
 
 ```bash
-gh pr view <PR_NUMBER> --json number,title,body,headRefName,baseRefName,author,createdAt,updatedAt,labels,reviewDecision,reviewRequests,reviews,checks,additions,deletions,changedFiles,files,comments,mergeable,isDraft,url
+gh pr view <PR_NUMBER> --json number,title,body,headRefName,baseRefName,author,createdAt,updatedAt,labels,reviewDecision,reviewRequests,reviews,statusCheckRollup,additions,deletions,changedFiles,files,comments,mergeable,isDraft,url
 ```
 
 Present the full breakdown:
@@ -82,3 +98,32 @@ If there are comments, show them with author and timestamp.
 
 **Reviews:**
 If there are reviews, show reviewer, state, and any body text.
+
+### If `$ARGUMENTS` contains "issue <number>" — Issue Detail Mode
+
+Run this command:
+
+```bash
+gh issue view <ISSUE_NUMBER> --json number,title,body,author,createdAt,updatedAt,labels,comments,state,url
+```
+
+Present the full breakdown:
+
+**Header:**
+```
+Issue #<number>: <title>
+<url>
+```
+
+**Status Block:**
+- State: Open / Closed
+- Author: `<login>`
+- Created: `<date>` (relative)
+- Updated: `<date>` (relative)
+- Labels: comma-separated or None
+
+**Description:**
+Show the full issue body.
+
+**Comments:**
+If there are comments, show them with author and timestamp.


### PR DESCRIPTION
## Summary
- Fixed `checks` → `statusCheckRollup` (correct gh CLI JSON field name)
- Added open issues table to summary mode (was only showing PRs)
- Added issue detail mode: `/pr-status issue 20`
- Updated CLAUDE.md skill description to reflect new capabilities

## Test plan
- [ ] `/pr-status` shows both PRs and issues tables
- [ ] `/pr-status <number>` shows PR detail without errors
- [ ] `/pr-status issue <number>` shows issue detail

🤖 Generated with [Claude Code](https://claude.com/claude-code)