### PR TITLE
feat: MCP Obsidian server installer (macOS only)

### DIFF
--- a/mainmenu/llm/mcp/README.md
+++ b/mainmenu/llm/mcp/README.md
@@ -6,9 +6,23 @@ MCP servers extend AI assistants (Claude Desktop, Claude Code, etc.) with access
 
 ## Available Scripts
 
-| Script | Description | OS |
+| Action | Description | OS |
 |--------|-------------|----|
-| [mcp-obsidian.sh](mcp-obsidian.sh) | MCP server for Obsidian vault access (read/write/search notes) | macOS |
+| [mcp-obsidian/](mcp-obsidian/) | MCP server for Obsidian vault access (read/write/search notes) | macOS |
+
+## Folder Structure
+
+Each MCP server follows the modular OS-specific structure:
+
+```
+mcp-obsidian/
+├── meta.yaml        # Metadata (name, description, supported OS)
+├── _common.sh       # Shared logic (node checks, Claude Code config)
+├── macos.sh         # macOS implementation
+└── README.md        # Action-level docs
+```
+
+See [CONTRIBUTING.md](../../CONTRIBUTING.md) for how to add new MCP servers or OS support.
 
 ## Prerequisites
 

--- a/mainmenu/llm/mcp/mcp-obsidian/README.md
+++ b/mainmenu/llm/mcp/mcp-obsidian/README.md
@@ -1,0 +1,35 @@
+# MCP Obsidian Server
+
+Installs and configures the [MCP Obsidian server](https://github.com/bitbonsai/mcp-obsidian) — a Model Context Protocol server that gives AI assistants (Claude Desktop, Claude Code) safe read/write access to your Obsidian vaults.
+
+## What It Does
+
+- Checks Obsidian is installed
+- Checks Node.js v18+ is available
+- Auto-discovers your Obsidian vaults
+- Downloads the MCP server package via npx
+- Configures Claude Desktop and Claude Code MCP settings
+- Full uninstall support (cleans up all config)
+
+## Supported OSes
+
+| OS | Status |
+|----|--------|
+| macOS | Supported |
+| Ubuntu 22.04 | Not yet |
+| Ubuntu 24.04 | Not yet |
+| Debian | Not yet |
+| Kali Linux | Not yet |
+| Fedora | Not yet |
+
+## Features Provided by the MCP Server
+
+- Read, write, delete, move notes
+- Search content and frontmatter
+- Manage tags (add, remove, list)
+- Batch read multiple notes
+- Safe YAML frontmatter handling
+
+## Source
+
+- [github.com/bitbonsai/mcp-obsidian](https://github.com/bitbonsai/mcp-obsidian)

--- a/mainmenu/llm/mcp/mcp-obsidian/_common.sh
+++ b/mainmenu/llm/mcp/mcp-obsidian/_common.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+# Shared functions for MCP Obsidian — sourced by all OS scripts
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MENU_ROOT="${MENU_ROOT:-$(cd "$SCRIPT_DIR" && while [[ ! -f "menu.py" ]] && [[ "$PWD" != "/" ]]; do cd ..; done; pwd)}"
+source "$MENU_ROOT/.lib/platform.sh"
+
+LOG_DIR="$MENU_ROOT/.docs/logs"
+SCRIPT_NAME="mcp-obsidian"
+LOG_FILE="$LOG_DIR/${SCRIPT_NAME}_$(date +%Y%m%d_%H%M%S).log"
+
+mkdir -p "$LOG_DIR"
+
+CLAUDE_DESKTOP_CONFIG="$HOME/Library/Application Support/Claude/claude_desktop_config.json"
+
+# ── Check Node.js v18+ ──────────────────────────────────────────────────────
+check_node() {
+    if ! command -v node &>/dev/null; then
+        log_error "Node.js is required but not installed."
+        log_info "Install with your package manager (e.g., brew install node)"
+        exit 1
+    fi
+
+    local node_version
+    node_version="$(node --version | sed 's/v//')"
+    local node_major="${node_version%%.*}"
+    if [[ "$node_major" -lt 18 ]]; then
+        log_error "Node.js v18+ required. Current: v${node_version}"
+        exit 1
+    fi
+    log_info "Node.js v${node_version} found"
+}
+
+# ── Configure Claude Code ───────────────────────────────────────────────────
+configure_claude_code() {
+    local vault_path="$1"
+
+    log_step "Configuring Claude Code MCP..."
+
+    if command -v claude &>/dev/null; then
+        claude mcp add obsidian --scope user npx @mauricio.wolff/mcp-obsidian@latest "$vault_path"
+        log_success "Claude Code configured with Obsidian MCP server"
+    else
+        log_warn "Claude Code CLI not found — skipping Claude Code config."
+        log_info "To add manually later: claude mcp add obsidian --scope user npx @mauricio.wolff/mcp-obsidian@latest \"$vault_path\""
+    fi
+}
+
+# ── Remove from Claude Code ─────────────────────────────────────────────────
+remove_claude_code() {
+    if command -v claude &>/dev/null; then
+        claude mcp remove obsidian --scope user 2>/dev/null || true
+        log_success "Removed obsidian from Claude Code config"
+    fi
+}

--- a/mainmenu/llm/mcp/mcp-obsidian/macos.sh
+++ b/mainmenu/llm/mcp/mcp-obsidian/macos.sh
@@ -1,47 +1,12 @@
 #!/bin/bash
-# ---
-# name: "MCP Obsidian Server"
-# description: "MCP server for AI access to Obsidian vaults (read/write/search notes)"
-# version: "1.0.0"
-# author: "bitbonsai (Mauricio Wolff)"
-# type: install
-# root: false
-# order: 10
-# hidden: false
-# installed: false
-# check_command: "npx @mauricio.wolff/mcp-obsidian@latest --help"
-# dependencies:
-#   - node
-# tags:
-#   - llm
-#   - mcp
-#   - obsidian
-#   - ai
-#   - notes
-# ---
+# macOS implementation — do NOT add YAML headers here (use meta.yaml)
 
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-SCRIPT_NAME="$(basename "${BASH_SOURCE[0]}" .sh)"
-MENU_ROOT="${MENU_ROOT:-$(cd "$SCRIPT_DIR" && while [[ ! -f "menu.py" ]] && [[ "$PWD" != "/" ]]; do cd ..; done; pwd)}"
-source "$MENU_ROOT/.lib/platform.sh"
+source "${SCRIPT_DIR}/_common.sh"
 
-LOG_DIR="$MENU_ROOT/.docs/logs"
-mkdir -p "$LOG_DIR"
-LOG_FILE="$LOG_DIR/${SCRIPT_NAME}_$(date +%Y%m%d_%H%M%S).log"
 exec > >(tee -a "$LOG_FILE") 2>&1
-
-CLAUDE_DESKTOP_CONFIG="$HOME/Library/Application Support/Claude/claude_desktop_config.json"
-CLAUDE_CODE_CONFIG="$HOME/.claude.json"
-
-# ── macOS-only gate ──────────────────────────────────────────────────────────
-check_macos() {
-    if [[ "$(uname -s)" != "Darwin" ]]; then
-        log_error "This script is macOS only. Linux binaries for Obsidian are not yet supported."
-        exit 1
-    fi
-}
 
 # ── Obsidian installed gate ──────────────────────────────────────────────────
 check_obsidian() {
@@ -95,7 +60,7 @@ find_vaults() {
     fi
 }
 
-# ── Configure Claude Desktop ────────────────────────────────────────────────
+# ── Configure Claude Desktop (macOS paths) ──────────────────────────────────
 configure_claude_desktop() {
     local vault_path="$1"
 
@@ -107,19 +72,16 @@ configure_claude_desktop() {
     log_step "Configuring Claude Desktop MCP..."
 
     if [[ -f "$CLAUDE_DESKTOP_CONFIG" ]]; then
-        # Backup existing config
         cp "$CLAUDE_DESKTOP_CONFIG" "${CLAUDE_DESKTOP_CONFIG}.bak"
         log_info "Backed up existing config to claude_desktop_config.json.bak"
 
-        # Check if obsidian server already configured
         if grep -q '"obsidian"' "$CLAUDE_DESKTOP_CONFIG" 2>/dev/null; then
             log_warn "Obsidian MCP already configured in Claude Desktop — skipping."
             return
         fi
 
-        # Add obsidian to existing mcpServers using python for safe JSON manipulation
         python3 -c "
-import json, sys
+import json
 with open('$CLAUDE_DESKTOP_CONFIG', 'r') as f:
     config = json.load(f)
 config.setdefault('mcpServers', {})
@@ -131,7 +93,6 @@ with open('$CLAUDE_DESKTOP_CONFIG', 'w') as f:
     json.dump(config, f, indent=2)
 "
     else
-        # Create new config
         mkdir -p "$(dirname "$CLAUDE_DESKTOP_CONFIG")"
         cat > "$CLAUDE_DESKTOP_CONFIG" <<JSONEOF
 {
@@ -148,44 +109,31 @@ JSONEOF
     log_success "Claude Desktop configured with Obsidian MCP server"
 }
 
-# ── Configure Claude Code ───────────────────────────────────────────────────
-configure_claude_code() {
-    local vault_path="$1"
-
-    log_step "Configuring Claude Code MCP..."
-
-    if command -v claude &>/dev/null; then
-        claude mcp add obsidian --scope user npx @mauricio.wolff/mcp-obsidian@latest "$vault_path"
-        log_success "Claude Code configured with Obsidian MCP server"
-    else
-        log_warn "Claude Code CLI not found — skipping Claude Code config."
-        log_info "To add manually later: claude mcp add obsidian --scope user npx @mauricio.wolff/mcp-obsidian@latest \"$vault_path\""
+# ── Remove from Claude Desktop ──────────────────────────────────────────────
+remove_claude_desktop() {
+    if [[ -f "$CLAUDE_DESKTOP_CONFIG" ]]; then
+        if grep -q '"obsidian"' "$CLAUDE_DESKTOP_CONFIG" 2>/dev/null; then
+            python3 -c "
+import json
+with open('$CLAUDE_DESKTOP_CONFIG', 'r') as f:
+    config = json.load(f)
+if 'mcpServers' in config and 'obsidian' in config['mcpServers']:
+    del config['mcpServers']['obsidian']
+with open('$CLAUDE_DESKTOP_CONFIG', 'w') as f:
+    json.dump(config, f, indent=2)
+"
+            log_success "Removed obsidian from Claude Desktop config"
+        fi
     fi
 }
 
 # ── Install ──────────────────────────────────────────────────────────────────
 install() {
-    log_info "Installing MCP Obsidian Server..."
+    log_info "Installing MCP Obsidian Server on macOS..."
     log_info "Log file: $LOG_FILE"
 
-    check_macos
     check_obsidian
-
-    # Check Node.js
-    if ! command -v node &>/dev/null; then
-        log_error "Node.js is required but not installed."
-        log_info "Install with: brew install node"
-        exit 1
-    fi
-
-    local node_version
-    node_version="$(node --version | sed 's/v//')"
-    local node_major="${node_version%%.*}"
-    if [[ "$node_major" -lt 18 ]]; then
-        log_error "Node.js v18+ required. Current: v${node_version}"
-        exit 1
-    fi
-    log_info "Node.js v${node_version} found"
+    check_node
 
     # Pre-cache the package
     log_step "Downloading MCP Obsidian server package..."
@@ -217,29 +165,9 @@ install() {
 uninstall() {
     log_info "Removing MCP Obsidian Server configuration..."
 
-    # Remove from Claude Desktop config
-    if [[ -f "$CLAUDE_DESKTOP_CONFIG" ]]; then
-        if grep -q '"obsidian"' "$CLAUDE_DESKTOP_CONFIG" 2>/dev/null; then
-            python3 -c "
-import json
-with open('$CLAUDE_DESKTOP_CONFIG', 'r') as f:
-    config = json.load(f)
-if 'mcpServers' in config and 'obsidian' in config['mcpServers']:
-    del config['mcpServers']['obsidian']
-with open('$CLAUDE_DESKTOP_CONFIG', 'w') as f:
-    json.dump(config, f, indent=2)
-"
-            log_success "Removed obsidian from Claude Desktop config"
-        fi
-    fi
+    remove_claude_desktop
+    remove_claude_code
 
-    # Remove from Claude Code
-    if command -v claude &>/dev/null; then
-        claude mcp remove obsidian --scope user 2>/dev/null || true
-        log_success "Removed obsidian from Claude Code config"
-    fi
-
-    # Clear npx cache for this package
     log_info "Clearing cached package..."
     npm cache clean --force 2>/dev/null || true
 
@@ -247,7 +175,9 @@ with open('$CLAUDE_DESKTOP_CONFIG', 'w') as f:
     mark_installed false
 }
 
-case "${1:-install}" in
+ACTION="${1:-install}"
+
+case "$ACTION" in
     install) install ;;
     uninstall) uninstall ;;
     *) echo "Usage: $0 {install|uninstall}"; exit 1 ;;

--- a/mainmenu/llm/mcp/mcp-obsidian/meta.yaml
+++ b/mainmenu/llm/mcp/mcp-obsidian/meta.yaml
@@ -1,0 +1,19 @@
+name: "MCP Obsidian Server"
+description: "MCP server for AI access to Obsidian vaults (read/write/search notes)"
+version: "1.0.0"
+author: "bitbonsai (Mauricio Wolff)"
+type: install
+root: false
+order: 10
+hidden: false
+check_command: "npx @mauricio.wolff/mcp-obsidian@latest --help"
+dependencies:
+  - node
+tags:
+  - llm
+  - mcp
+  - obsidian
+  - ai
+  - notes
+supported_os:
+  - macos


### PR DESCRIPTION
## Summary
- New MCP server installer for [Obsidian](https://github.com/bitbonsai/mcp-obsidian) under `mainmenu/llm/mcp/mcp-obsidian/`
- **Follows the modular OS-specific structure** (issue #22):
  - `meta.yaml` — metadata, `supported_os: [macos]`
  - `_common.sh` — shared logic (node check, Claude Code config)
  - `macos.sh` — macOS-specific (Obsidian gate, vault discovery, Claude Desktop config)
  - `README.md` — action-level docs with OS support table
- **No monolithic scripts** — no YAML headers in .sh files, no OS detection `if`/`case` blocks
- **macOS only** — checks `/Applications/Obsidian.app` exists; exits cleanly if not installed
- Auto-discovers Obsidian vaults from common locations
- Configures both Claude Desktop and Claude Code MCP settings
- Full install/uninstall with config backup and cleanup
- New `mcp/` submenu under `llm/` with README

## Test plan
- [ ] Run `macos.sh install` on macOS with Obsidian — should find vaults and configure
- [ ] Run `macos.sh install` on macOS without Obsidian — should exit with download link
- [ ] Verify Claude Desktop config is correctly updated (not overwritten)
- [ ] Verify Claude Code MCP is added via `claude mcp add`
- [ ] Test `macos.sh uninstall` removes config from both clients
- [ ] Verify folder structure matches modular architecture (meta.yaml, _common.sh, macos.sh)

🤖 Generated with [Claude Code](https://claude.com/claude-code)