### PR TITLE
docs: make all entry-point docs LLM-ready for three-tier metadata

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -34,62 +34,64 @@ menu-installer/
 
 ### Menu Generation Rules
 
-1. **Folders** = Menu/Submenu names (display name from folder name, titlecased)
-2. **Scripts (.sh)** = Menu items (name from YAML header)
-3. **Dot-prefixed** = Hidden from menu (`.configs`, `.docs`, etc.)
-4. **YAML Headers** = Script metadata for menu display and execution
+1. **Folders with `meta.yaml`** = Tier 1 modular scripts (OS-specific, resolved per platform)
+2. **Scripts (.sh) with sibling `.meta.yaml`** = Tier 2 scripts (OS-agnostic, most common)
+3. **Scripts (.sh) with inline `# ---` header** = Tier 3 legacy (deprecated, still parsed)
+4. **Folders without `meta.yaml`** = Submenus (display name from folder name, titlecased)
+5. **Dot-prefixed** = Hidden from menu (`.configs`, `.docs`, etc.)
+6. **Underscore-prefixed** (`_common.sh`) = Hidden from menu
 
-## Script YAML Header Format
+## Script Metadata System
 
-All executable scripts must have a YAML header:
+Scripts use **externalised YAML metadata** — not inline headers. There are three tiers:
 
-```bash
-#!/bin/bash
-# ---
-# name: "Human Readable Name"
-# description: "What this script does"
-# version: "1.0.0"
-# author: "Author Name"
-# type: install
-# root: true|false
-# order: 10
-# hidden: false
-# installed: false
-# check_command: "myapp --version"
-# check_path: "/usr/bin/myapp"
-# uninstall: "path/to/uninstall_script.sh"  # Optional
-# dependencies:
-#   - package1
-#   - package2
-# tags:
-#   - category1
-#   - category2
-# ---
+| Tier | Structure | When to Use |
+|------|-----------|-------------|
+| **Tier 1** — Modular folder | `<tool>/meta.yaml` + `_common.sh` + `macos.sh`, `linux.sh` | Different code per OS (10 scripts) |
+| **Tier 2** — Sibling `.meta.yaml` | `<tool>.sh` + `<tool>.meta.yaml` | Uses `pkg_install`/`pkg_remove` from platform.sh (71 scripts) |
+| **Tier 3** — Inline YAML header | `# --- ... # ---` inside `.sh` | **Deprecated.** Do not use for new scripts |
+
+### Tier 2 Example (most common)
+
+```yaml
+# htop.meta.yaml
+name: "htop"
+description: "Interactive process viewer with color display"
+type: install
+root: true
+order: 10
+installed: false
+check_command: "htop --version"
+tags:
+  - monitoring
+  - process
+supported_os:
+  - macos
+  - kali
+  - debian
+  - ubuntu
 ```
 
-### Header Fields
+### Required Metadata Fields
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | name | string | Yes | Display name in menu |
 | description | string | Yes | Brief description shown in menu |
-| version | string | No | Script version |
-| author | string | No | Script author |
-| type | string | No | `install` (Install/Uninstall) or `config` (Run only) |
+| type | string | Yes | `install`, `config`, or `tool` |
 | root | boolean | Yes | Requires sudo/root privileges |
 | order | integer | Yes | Sort order in menu (lower = higher) |
-| hidden | boolean | No | If true, hide from menu |
-| installed | boolean | No | Tracks installation state |
-| check_command | string | No | Command to verify installation (e.g., `node --version`) |
-| check_path | string | No | Path to check if exists (e.g., `/usr/bin/node`) |
-| uninstall | string | No | Path to uninstall script |
-| dependencies | array | No | Required packages |
-| tags | array | No | Categorization tags |
+| supported_os | array | Yes | Which OSes this script supports (`macos`, `kali`, `debian`, `ubuntu`) |
+
+For the full field reference and Tier 1 folder structure, see:
+- **Contributing guide:** `mainmenu/CONTRIBUTING.md`
+- **Full technical spec:** `.docs/technical_manuals/os-modular-architecture.md`
 
 ### Script Types
 
 - **`type: install`** (default) - Shows Install/Uninstall actions, tracks installation state
 - **`type: config`** - Shows "Run" action only, for utilities/config scripts
+- **`type: tool`** - Educational scripts that use an installed binary (requires `binary` field)
 
 ## Menu System
 
@@ -102,7 +104,7 @@ All executable scripts must have a YAML header:
 ### Features
 
 - Dynamic menu generation from folder structure
-- YAML header parsing for script metadata
+- Three-tier metadata parsing (folder `meta.yaml`, sibling `.meta.yaml`, legacy inline)
 - Installation state tracking
 - Log viewing capability
 - Uninstall support
@@ -134,7 +136,8 @@ Every menu folder MUST have:
 ### Documentation Checklist
 
 When adding a new script or folder:
-- [ ] Script has complete YAML header
+- [ ] Metadata file exists (`meta.yaml` for Tier 1 or `.meta.yaml` for Tier 2)
+- [ ] `supported_os` field lists all tested OSes
 - [ ] Folder has README.md
 - [ ] User manual exists in `.docs/user_manuals/`
 - [ ] Technical manual exists in `.docs/technical_manuals/`
@@ -144,25 +147,35 @@ When adding a new script or folder:
 
 ```
 .docs/templates/
-├── script_template.sh        # Install script template
-├── config_template.sh        # Config/utility script template
-├── folder_readme_template.md # Folder README template
-├── user_doc_template.md      # User manual template
-└── technical_doc_template.md # Technical manual template
+├── script_template.sh            # Tier 2 install script template
+├── script_template.meta.yaml     # Tier 2 install metadata template
+├── config_template.sh            # Tier 2 config/utility script template
+├── config_template.meta.yaml     # Tier 2 config metadata template
+├── tool_template.sh              # Tier 2 tool/education script template
+├── tool_template.meta.yaml       # Tier 2 tool metadata template
+├── tier1_template/               # Tier 1 modular folder template
+│   ├── meta.yaml                 # Tier 1 metadata template
+│   ├── _common.sh                # Shared functions template
+│   ├── macos.sh                  # macOS script template
+│   └── linux.sh                  # Linux script template
+├── folder_readme_template.md     # Folder README template
+├── user_doc_template.md          # User manual template
+└── technical_doc_template.md     # Technical manual template
 ```
 
 ## Development Guidelines
 
 ### Adding New Scripts
 
-1. Create script in appropriate folder under `mainmenu/`
-2. Copy from `.docs/templates/script_template.sh` or `config_template.sh`
-3. Add YAML header with all required fields
-4. Set `check_command` and/or `check_path` for installation detection
-5. Use logging functions to write to `.docs/logs/`
-6. Test with `bash script.sh install`
-7. Update folder README.md with new script
-8. Update user and technical manuals
+1. Decide the tier: Tier 2 (OS-agnostic, most common) or Tier 1 (OS-specific)
+2. Create script in appropriate folder under `mainmenu/`
+3. Copy from `.docs/templates/` (use `script_template.sh` + `script_template.meta.yaml` for Tier 2, or `tier1_template/` for Tier 1)
+4. Create the companion `.meta.yaml` (Tier 2) or `meta.yaml` (Tier 1) with all required fields including `supported_os`
+5. Set `check_command` and/or `check_path` for installation detection
+6. Use logging functions to write to `.docs/logs/`
+7. Test with `bash script.sh install`
+8. Update folder README.md with new script
+9. Update user and technical manuals
 
 ### Creating Submenus
 

--- a/.docs/templates/config_template.meta.yaml
+++ b/.docs/templates/config_template.meta.yaml
@@ -1,0 +1,23 @@
+# Tier 2 metadata template for config/utility scripts.
+# Place this file alongside your .sh script:
+#   mainmenu/<category>/<tool-name>.meta.yaml
+#
+# Full reference: .docs/technical_manuals/os-modular-architecture.md
+
+name: "Config Script Name"        # Display name in the menu
+description: "What this config/utility does"
+version: "1.0.0"
+author: "Your Name"
+type: config                       # config = Run action only (no install/uninstall)
+root: false                        # true if needs sudo
+order: 50                          # Sort order in menu (lower = higher)
+hidden: false
+installed: false
+tags:
+  - config
+  - utility
+supported_os:                      # REQUIRED — list only OSes you have tested
+  - macos
+  - kali
+  - debian
+  - ubuntu

--- a/.docs/templates/config_template.sh
+++ b/.docs/templates/config_template.sh
@@ -1,21 +1,7 @@
 #!/bin/bash
-# ---
-# name: "Config Script Name"
-# description: "Brief description of what this config/utility does"
-# version: "1.0.0"
-# author: "Your Name"
-# type: config
-# root: false
-# order: 50
-# hidden: false
-# installed: false
-# check_command: ""
-# check_path: ""
-# dependencies: []
-# tags:
-#   - config
-#   - utility
-# ---
+# Metadata lives in the companion .meta.yaml file (NOT inline).
+# Copy config_template.meta.yaml alongside this script and fill in the fields.
+# See: .docs/technical_manuals/os-modular-architecture.md for full reference.
 
 #######################################
 # CONFIG/UTILITY TEMPLATE

--- a/.docs/templates/script_template.meta.yaml
+++ b/.docs/templates/script_template.meta.yaml
@@ -1,0 +1,27 @@
+# Tier 2 metadata template for install scripts.
+# Place this file alongside your .sh script:
+#   mainmenu/<category>/<tool-name>.meta.yaml
+#
+# Full reference: .docs/technical_manuals/os-modular-architecture.md
+
+name: "Human Readable Name"       # Display name in the menu
+description: "What this script does"  # Brief description shown in menu
+version: "1.0.0"
+author: "Your Name"
+type: install                      # install (Install/Uninstall) or config (Run only)
+root: false                        # true if needs sudo (Linux); macOS uses Homebrew without sudo
+order: 50                          # Sort order in menu (lower = higher)
+hidden: false                      # true to exclude from menu
+installed: false                   # Managed by mark_installed — leave as false
+check_command: "myapp --version"   # Command to verify installation
+check_path: "/usr/bin/myapp"       # Alternative: path to check existence
+dependencies:
+  - curl
+  - git
+tags:
+  - category
+supported_os:                      # REQUIRED — list only OSes you have tested
+  - macos
+  - kali
+  - debian
+  - ubuntu

--- a/.docs/templates/script_template.sh
+++ b/.docs/templates/script_template.sh
@@ -1,27 +1,7 @@
 #!/bin/bash
-# ---
-# name: "Script Display Name"
-# description: "Brief description of what this script does"
-# version: "1.0.0"
-# author: "Your Name"
-# type: install
-# root: false
-# order: 50
-# hidden: false
-# installed: false
-# check_command: "myapp --version"
-# check_path: "/usr/bin/myapp:~/.local/bin/myapp"
-# uninstall: ""
-# dependencies:
-#   - curl
-#   - git
-# tags:
-#   - category
-# ---
-#
-# type options:
-#   install - Shows Install/Uninstall actions (default)
-#   config  - Shows Run action only (for utilities/config scripts)
+# Metadata lives in the companion .meta.yaml file (NOT inline).
+# Copy script_template.meta.yaml alongside this script and fill in the fields.
+# See: .docs/technical_manuals/os-modular-architecture.md for full reference.
 
 #######################################
 # SCRIPT TEMPLATE

--- a/.docs/templates/tier1_template/_common.sh
+++ b/.docs/templates/tier1_template/_common.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# Shared functions for <tool-name> — sourced by all OS scripts.
+# Do NOT add YAML headers here (metadata lives in meta.yaml).
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MENU_ROOT="${MENU_ROOT:-$(cd "$SCRIPT_DIR" && while [[ ! -f "menu.py" ]] && [[ "$PWD" != "/" ]]; do cd ..; done; pwd)}"
+
+# Source platform detection (provides log_info, log_error, log_success, pkg_install, etc.)
+source "$MENU_ROOT/.lib/platform.sh"
+
+# Setup logging
+LOG_DIR="$MENU_ROOT/.docs/logs"
+SCRIPT_NAME="$(basename "$SCRIPT_DIR")"
+mkdir -p "$LOG_DIR"
+LOG_FILE="$LOG_DIR/${SCRIPT_NAME}_$(date +%Y%m%d_%H%M%S).log"
+
+#######################################
+# Add shared helper functions below
+#######################################

--- a/.docs/templates/tier1_template/linux.sh
+++ b/.docs/templates/tier1_template/linux.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+# Generic Linux implementation — do NOT add YAML headers here (metadata lives in meta.yaml).
+# This covers Debian, Ubuntu, and Kali unless you create distro-specific scripts.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/_common.sh"
+
+ACTION="${1:-install}"
+
+case "$ACTION" in
+    install)
+        require_root
+        log_info "Installing <tool> on Linux..."
+        exec > >(tee -a "$LOG_FILE") 2>&1
+
+        #######################################
+        # YOUR Linux INSTALLATION LOGIC HERE
+        #######################################
+
+        # Example: apt-get install -y <pkg>
+
+        #######################################
+        # END INSTALLATION LOGIC
+        #######################################
+
+        mark_installed true
+        log_success "<tool> installed successfully"
+        ;;
+    uninstall)
+        require_root
+        log_info "Uninstalling <tool> from Linux..."
+        exec > >(tee -a "$LOG_FILE") 2>&1
+
+        #######################################
+        # YOUR Linux UNINSTALLATION LOGIC HERE
+        #######################################
+
+        # Example: apt-get remove -y <pkg>
+
+        #######################################
+        # END UNINSTALLATION LOGIC
+        #######################################
+
+        mark_installed false
+        log_success "<tool> uninstalled successfully"
+        ;;
+    *)
+        echo "Usage: $0 {install|uninstall}"
+        exit 1
+        ;;
+esac

--- a/.docs/templates/tier1_template/macos.sh
+++ b/.docs/templates/tier1_template/macos.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+# macOS implementation — do NOT add YAML headers here (metadata lives in meta.yaml).
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/_common.sh"
+
+ACTION="${1:-install}"
+
+case "$ACTION" in
+    install)
+        log_info "Installing <tool> on macOS..."
+        exec > >(tee -a "$LOG_FILE") 2>&1
+
+        #######################################
+        # YOUR macOS INSTALLATION LOGIC HERE
+        #######################################
+
+        # Example: brew install <pkg>
+
+        #######################################
+        # END INSTALLATION LOGIC
+        #######################################
+
+        mark_installed true
+        log_success "<tool> installed successfully"
+        ;;
+    uninstall)
+        log_info "Uninstalling <tool> from macOS..."
+        exec > >(tee -a "$LOG_FILE") 2>&1
+
+        #######################################
+        # YOUR macOS UNINSTALLATION LOGIC HERE
+        #######################################
+
+        # Example: brew uninstall <pkg>
+
+        #######################################
+        # END UNINSTALLATION LOGIC
+        #######################################
+
+        mark_installed false
+        log_success "<tool> uninstalled successfully"
+        ;;
+    *)
+        echo "Usage: $0 {install|uninstall}"
+        exit 1
+        ;;
+esac

--- a/.docs/templates/tier1_template/meta.yaml
+++ b/.docs/templates/tier1_template/meta.yaml
@@ -1,0 +1,26 @@
+# Tier 1 metadata template for OS-specific modular scripts.
+# This file lives inside the tool folder:
+#   mainmenu/<category>/<tool-name>/meta.yaml
+#
+# Full reference: .docs/technical_manuals/os-modular-architecture.md
+
+name: "Human Readable Name"       # Display name in the menu
+description: "What this script does"
+version: "1.0.0"
+author: "Your Name"
+type: install                      # install (Install/Uninstall) or config (Run only)
+root: false                        # true if needs sudo
+order: 10                          # Sort order in menu (lower = higher)
+hidden: false
+installed: false
+check_command: "tool --version"    # Command to verify installation
+check_path: "/usr/bin/tool"        # Alternative: path to check existence
+dependencies:
+  - package1
+tags:
+  - category1
+supported_os:                      # REQUIRED — list only the OS scripts you created below
+  - macos
+  - kali
+  - debian
+  - ubuntu

--- a/.docs/templates/tool_template.meta.yaml
+++ b/.docs/templates/tool_template.meta.yaml
@@ -1,0 +1,23 @@
+# Tier 2 metadata template for tool/education scripts.
+# Place this file alongside your .sh script:
+#   mainmenu/education/<category>/<tool>/<technique>/<script-name>.meta.yaml
+#
+# Full reference: .docs/technical_manuals/os-modular-architecture.md
+
+name: "Tool Script Name"          # Display name in the menu
+description: "What this script demonstrates"
+version: "1.0.0"
+author: "Your Name"
+type: tool                         # tool = requires a binary; menu blocks if missing
+root: false                        # true if needs raw socket access (e.g., nmap -sS)
+order: 50                          # Sort order in menu (lower = higher)
+hidden: false
+binary: "required-command"         # Command that must be on PATH (e.g., "nmap")
+tags:
+  - category
+  - tool-name
+supported_os:                      # REQUIRED — list only OSes you have tested
+  - macos
+  - kali
+  - debian
+  - ubuntu

--- a/.docs/templates/tool_template.sh
+++ b/.docs/templates/tool_template.sh
@@ -1,21 +1,10 @@
 #!/bin/bash
-# ---
-# name: "Tool Script Name"
-# description: "Brief description of what this script does"
-# version: "1.0.0"
-# author: "Your Name"
-# type: tool
-# root: false
-# order: 50
-# hidden: false
-# binary: "required-command"
-# tags:
-#   - category
-#   - tool-name
-# ---
+# Metadata lives in the companion .meta.yaml file (NOT inline).
+# Copy tool_template.meta.yaml alongside this script and fill in the fields.
+# See: .docs/technical_manuals/os-modular-architecture.md for full reference.
 #
 # type: tool — requires a binary to be installed before this script can run.
-# The menu checks the 'binary' field and blocks execution if not found.
+# The menu checks the 'binary' field in .meta.yaml and blocks execution if not found.
 #
 # Folder convention:
 #   mainmenu/education/{category}/{tool}/{technique}/this-script.sh

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,35 +21,48 @@ Drop your script into the matching category under `mainmenu/`:
 
 Need a new category? Create a folder under `mainmenu/` with a `README.md` describing it.
 
-### 2. Use the YAML header
+### 2. Create a `.meta.yaml` file
 
-Every script **must** include a YAML header so the menu system can discover it:
+Every script needs a companion metadata file. Create `<tool-name>.meta.yaml` alongside your script:
 
-```bash
-#!/bin/bash
-# ---
-# name: "tool-name"
-# description: "One-line description of what it does"
-# type: install
-# root: true
-# order: 20
-# check_command: "tool-name --version"
-# tags: "category, keyword"
-# ---
+```yaml
+# tool-name.meta.yaml
+name: "tool-name"
+description: "One-line description of what it does"
+type: install
+root: true
+order: 20
+installed: false
+check_command: "tool-name --version"
+tags:
+  - category
+  - keyword
+supported_os:
+  - macos
+  - kali
+  - debian
+  - ubuntu
 ```
 
 | Field | Required | Description |
 |-------|----------|-------------|
 | `name` | Yes | Display name in the menu |
 | `description` | Yes | Short description shown in detail view |
-| `type` | Yes | `install` (adds software) or `config` (run-only) |
+| `type` | Yes | `install` (adds software), `config` (run-only), or `tool` (education) |
 | `root` | Yes | `true` if the script needs sudo |
 | `order` | No | Sort position (lower = higher in menu) |
 | `check_command` | Yes* | Command to verify installation |
 | `check_path` | Yes* | Alternative: check if a file path exists |
-| `tags` | No | Comma-separated keywords for search |
+| `tags` | No | Categorisation tags |
+| `supported_os` | Yes | Which OSes this script supports |
 
 *Provide either `check_command` or `check_path`.
+
+> **Do NOT put YAML headers inside `.sh` files.** Inline `# ---` headers are a deprecated legacy format. All new scripts use external `.meta.yaml` files.
+
+### OS-specific scripts (Tier 1)
+
+If your script needs genuinely different code per OS (not just different package names), use the **modular folder** structure instead. See `mainmenu/CONTRIBUTING.md` for the full Tier 1 guide.
 
 ### 3. Source the platform library
 
@@ -119,21 +132,27 @@ mainmenu/education/{category}/{tool}/{technique}/your-script.sh
 
 Example: `mainmenu/education/network/nmap/scanning/quick-scan.sh`
 
-### 2. Use the YAML header
+### 2. Create a `.meta.yaml` file
 
-Tool scripts use `type: tool` and a `binary:` field:
+Tool scripts use `type: tool` and a `binary:` field. Create `<script-name>.meta.yaml` alongside your script:
 
-```bash
-#!/bin/bash
-# ---
-# name: "Quick Network Scan"
-# description: "Fast host discovery scan on local subnet"
-# type: tool
-# root: false
-# binary: "nmap"
-# order: 10
-# tags: "network, scanning, nmap"
-# ---
+```yaml
+# quick-scan.meta.yaml
+name: "Quick Network Scan"
+description: "Fast host discovery scan on local subnet"
+type: tool
+root: false
+binary: "nmap"
+order: 10
+tags:
+  - network
+  - scanning
+  - nmap
+supported_os:
+  - macos
+  - kali
+  - debian
+  - ubuntu
 ```
 
 | Field | Required | Description |
@@ -143,9 +162,12 @@ Tool scripts use `type: tool` and a `binary:` field:
 | `name` | Yes | Display name in the menu |
 | `description` | Yes | Short description |
 | `root` | Yes | `true` if needs sudo |
-| `tags` | No | Keywords for search |
+| `tags` | No | Categorisation tags |
+| `supported_os` | Yes | Which OSes this script supports |
 
 The menu checks if `binary` exists. If not, the script shows `⛔` and cannot be run.
+
+> **Do NOT put YAML headers inside `.sh` files.** Use the companion `.meta.yaml` file.
 
 ### 3. Source platform.sh and check the binary
 
@@ -211,7 +233,7 @@ Open a GitHub issue with:
 - One tool per PR (makes review easier)
 - Include the tool name and category in the PR title
 - Briefly describe what the tool does and why it belongs in the menu
-- Make sure the YAML header is complete
+- Make sure the `.meta.yaml` file is complete (including `supported_os`)
 
 ## Code Style
 


### PR DESCRIPTION
## Summary

- **CLAUDE.md** — Replaced "Script YAML Header Format" with "Script Metadata System" describing three-tier architecture, updated menu generation rules, checklist, templates listing, and dev guidelines
- **Root CONTRIBUTING.md** — Both install and tool script sections now use `.meta.yaml` approach with `supported_os`, added Tier 1 pointer
- **Script templates** — Stripped inline YAML headers from `script_template.sh`, `config_template.sh`, `tool_template.sh`; added companion `.meta.yaml` templates for each
- **Tier 1 template** — New `tier1_template/` directory with `meta.yaml`, `_common.sh`, `macos.sh`, `linux.sh`

## Test plan

- [ ] Grep templates for `# ---` — no active inline headers remain
- [ ] All YAML examples include `supported_os` field
- [ ] CLAUDE.md, root CONTRIBUTING.md, mainmenu CONTRIBUTING.md, and os-modular-architecture.md tell a consistent three-tier story
- [ ] A fresh LLM reading only CLAUDE.md or CONTRIBUTING.md would produce a correctly structured script

🤖 Generated with [Claude Code](https://claude.com/claude-code)