### PR TITLE
feat: add editors category with Obsidian app and CLI installers

### DIFF
--- a/.lib/platform.sh
+++ b/.lib/platform.sh
@@ -85,6 +85,7 @@ esac
 _pkg_map_macos() {
     case "$1" in
         # Cask installs (GUI apps)
+        obsidian)       echo "--cask obsidian" ;;
         zenmap)         echo "--cask zenmap" ;;
         wireshark)      echo "--cask wireshark" ;;
 

--- a/mainmenu/editors/README.md
+++ b/mainmenu/editors/README.md
@@ -1,0 +1,14 @@
+# Editors
+
+Text editors, note-taking apps, and related CLI tools.
+
+## Scripts
+
+| Script | Type | Description |
+|--------|------|-------------|
+| `obsidian/` | Tier 1 | Install/uninstall [Obsidian](https://obsidian.md) — markdown knowledge base |
+| `obsidian-cli.sh` | Tier 2 | Install/uninstall [NotesMD CLI](https://github.com/Yakitrak/notesmd-cli) — terminal CLI for Obsidian vaults |
+
+## Related
+
+- **MCP Obsidian Server** — available under `llm/mcp/mcp-obsidian/` (connects AI assistants to your Obsidian vault)

--- a/mainmenu/editors/obsidian-cli.meta.yaml
+++ b/mainmenu/editors/obsidian-cli.meta.yaml
@@ -1,0 +1,17 @@
+name: "NotesMD CLI (Obsidian CLI)"
+description: "Terminal CLI for Obsidian vaults — create, search, open, delete notes"
+type: install
+root: true
+order: 20
+installed: false
+check_command: "notesmd-cli --version"
+tags:
+  - editors
+  - obsidian
+  - cli
+  - notes
+supported_os:
+  - macos
+  - kali
+  - debian
+  - ubuntu

--- a/mainmenu/editors/obsidian-cli.sh
+++ b/mainmenu/editors/obsidian-cli.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+# Metadata in obsidian-cli.meta.yaml
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT_NAME="$(basename "${BASH_SOURCE[0]}" .sh)"
+MENU_ROOT="${MENU_ROOT:-$(cd "$SCRIPT_DIR" && while [[ ! -f "install_menu.sh" ]] && [[ "$PWD" != "/" ]]; do cd ..; done; pwd)}"
+source "$MENU_ROOT/.lib/platform.sh"
+
+ACTION="${1:-install}"
+if [ "$ACTION" = "install" ]; then
+    require_root
+
+    case "$NT_OS" in
+        macos)
+            brew tap yakitrak/yakitrak
+            brew install yakitrak/yakitrak/notesmd-cli
+            ;;
+        linux)
+            # notesmd-cli is Go-based; install from GitHub releases
+            latest_url=$(curl -fsSL https://api.github.com/repos/Yakitrak/obsidian-cli/releases/latest \
+                | grep "browser_download_url.*linux.*amd64" \
+                | head -1 \
+                | cut -d '"' -f 4)
+            if [[ -z "$latest_url" ]]; then
+                log_error "Could not find notesmd-cli release for Linux"
+                exit 1
+            fi
+            curl -fsSL "$latest_url" -o /tmp/notesmd-cli.tar.gz
+            tar -xzf /tmp/notesmd-cli.tar.gz -C /usr/local/bin/
+            rm -f /tmp/notesmd-cli.tar.gz
+            ;;
+    esac
+
+    mark_installed true
+    log_success "NotesMD CLI (Obsidian CLI) installed!"
+    log_info "Run 'notesmd-cli --help' to get started."
+else
+    require_root
+
+    case "$NT_OS" in
+        macos)
+            brew uninstall yakitrak/yakitrak/notesmd-cli 2>/dev/null || true
+            ;;
+        linux)
+            rm -f /usr/local/bin/notesmd-cli
+            ;;
+    esac
+
+    mark_installed false
+    log_success "NotesMD CLI uninstalled."
+fi

--- a/mainmenu/editors/obsidian/_common.sh
+++ b/mainmenu/editors/obsidian/_common.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# Shared functions for obsidian — sourced by all OS scripts.
+# Do NOT add YAML headers here (metadata lives in meta.yaml).
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MENU_ROOT="${MENU_ROOT:-$(cd "$SCRIPT_DIR" && while [[ ! -f "install_menu.sh" ]] && [[ "$PWD" != "/" ]]; do cd ..; done; pwd)}"
+
+source "$MENU_ROOT/.lib/platform.sh"
+
+LOG_DIR="$MENU_ROOT/.docs/logs"
+SCRIPT_NAME="$(basename "$SCRIPT_DIR")"
+mkdir -p "$LOG_DIR"
+LOG_FILE="$LOG_DIR/${SCRIPT_NAME}_$(date +%Y%m%d_%H%M%S).log"

--- a/mainmenu/editors/obsidian/linux.sh
+++ b/mainmenu/editors/obsidian/linux.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+# Linux implementation — do NOT add YAML headers here (metadata lives in meta.yaml).
+# Obsidian is not in apt repos; downloads .deb from GitHub releases.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/_common.sh"
+
+OBSIDIAN_DEB="/tmp/obsidian_latest.deb"
+
+ACTION="${1:-install}"
+
+case "$ACTION" in
+    install)
+        require_root
+        log_info "Installing Obsidian on Linux..."
+        exec > >(tee -a "$LOG_FILE") 2>&1
+
+        # Get latest .deb URL from GitHub releases
+        log_step "Fetching latest Obsidian release..."
+        DEB_URL=$(curl -fsSL https://api.github.com/repos/obsidianmd/obsidian-releases/releases/latest \
+            | grep "browser_download_url.*amd64\.deb" \
+            | head -1 \
+            | cut -d '"' -f 4)
+
+        if [[ -z "$DEB_URL" ]]; then
+            log_error "Could not find Obsidian .deb release"
+            exit 1
+        fi
+
+        log_step "Downloading: $DEB_URL"
+        curl -fsSL "$DEB_URL" -o "$OBSIDIAN_DEB"
+
+        log_step "Installing .deb package..."
+        dpkg -i "$OBSIDIAN_DEB" || apt-get install -f -y
+        rm -f "$OBSIDIAN_DEB"
+
+        mark_installed true
+        log_success "Obsidian installed successfully"
+        ;;
+    uninstall)
+        require_root
+        log_info "Uninstalling Obsidian from Linux..."
+        exec > >(tee -a "$LOG_FILE") 2>&1
+        apt-get remove -y obsidian 2>/dev/null || true
+        mark_installed false
+        log_success "Obsidian uninstalled successfully"
+        ;;
+    *)
+        echo "Usage: $0 {install|uninstall}"
+        exit 1
+        ;;
+esac

--- a/mainmenu/editors/obsidian/macos.sh
+++ b/mainmenu/editors/obsidian/macos.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# macOS implementation — do NOT add YAML headers here (metadata lives in meta.yaml).
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/_common.sh"
+
+ACTION="${1:-install}"
+
+case "$ACTION" in
+    install)
+        log_info "Installing Obsidian on macOS..."
+        exec > >(tee -a "$LOG_FILE") 2>&1
+        brew install --cask obsidian
+        mark_installed true
+        log_success "Obsidian installed successfully"
+        ;;
+    uninstall)
+        log_info "Uninstalling Obsidian from macOS..."
+        exec > >(tee -a "$LOG_FILE") 2>&1
+        brew uninstall --cask obsidian 2>/dev/null || true
+        mark_installed false
+        log_success "Obsidian uninstalled successfully"
+        ;;
+    *)
+        echo "Usage: $0 {install|uninstall}"
+        exit 1
+        ;;
+esac

--- a/mainmenu/editors/obsidian/meta.yaml
+++ b/mainmenu/editors/obsidian/meta.yaml
@@ -1,0 +1,18 @@
+name: "Obsidian"
+description: "Markdown-based knowledge base and note-taking app"
+type: install
+root: true
+order: 10
+installed: false
+check_command: ""
+check_path: "/Applications/Obsidian.app:/usr/bin/obsidian"
+tags:
+  - editors
+  - notes
+  - markdown
+  - knowledge-base
+supported_os:
+  - macos
+  - kali
+  - debian
+  - ubuntu


### PR DESCRIPTION
## Summary

- New **`mainmenu/editors/`** category for text editors and note-taking tools
- **Obsidian app** (Tier 1 modular folder): `brew install --cask obsidian` on macOS, `.deb` from GitHub releases on Linux
- **NotesMD CLI** (Tier 2): `brew tap yakitrak/yakitrak && brew install notesmd-cli` on macOS, GitHub release binary on Linux
- Added `obsidian` cask mapping to `.lib/platform.sh`
- MCP Obsidian server already exists at `llm/mcp/mcp-obsidian/` (no changes needed)

This sets up the `editors/` category which can later house vim, neovim, sublime, etc.

## Test plan

- [ ] `brew install --cask obsidian` works via macOS script (already installed — verify check_path detects it)
- [ ] `brew tap yakitrak/yakitrak && brew install yakitrak/yakitrak/notesmd-cli` installs CLI
- [ ] `notesmd-cli --version` confirms installation
- [ ] Menu discovers both scripts under Editors submenu

🤖 Generated with [Claude Code](https://claude.com/claude-code)