### PR TITLE
fix: add local branch cleanup to merge/ship-it scripts

### DIFF
--- a/.claude/scripts/merge-pr.sh
+++ b/.claude/scripts/merge-pr.sh
@@ -189,16 +189,25 @@ gh pr merge "$PR_NUMBER" $STRATEGY --delete-branch $USE_ADMIN || {
 }
 echo "    Merged."
 
-# --- Return to main ---
+# --- Return to main and clean up ---
 echo ""
 echo "==> Returning to main..."
 git checkout main 2>/dev/null || true
 git pull origin main || true
+
+# Delete local branch if it still exists
+if git show-ref --verify --quiet "refs/heads/$PR_HEAD" 2>/dev/null; then
+    git branch -d "$PR_HEAD" 2>/dev/null || git branch -D "$PR_HEAD" 2>/dev/null || true
+    echo "    Local branch '$PR_HEAD' deleted."
+fi
+
+# Prune stale remote tracking refs
+git remote prune origin 2>/dev/null || true
 
 # --- Done ---
 echo ""
 echo "================================================"
 echo "  PR #$PR_NUMBER merged to main."
 echo "  Strategy: $STRATEGY"
-echo "  Branch '$PR_HEAD' deleted."
+echo "  Branch '$PR_HEAD' deleted (local + remote)."
 echo "================================================"

--- a/.claude/scripts/ship-it.sh
+++ b/.claude/scripts/ship-it.sh
@@ -120,15 +120,25 @@ else
 fi
 echo "    Merged and branch deleted."
 
-# --- Step 6: Return to main ---
+# --- Step 6: Return to main and clean up ---
 echo ""
 echo "==> Step 6: Returning to main..."
 git checkout main || { echo "ERROR: Could not checkout main"; exit 1; }
 git pull origin main || { echo "ERROR: Could not pull main"; exit 1; }
 
+# Delete local branch if it still exists
+if git show-ref --verify --quiet "refs/heads/$BRANCH" 2>/dev/null; then
+    git branch -d "$BRANCH" 2>/dev/null || git branch -D "$BRANCH" 2>/dev/null || true
+    echo "    Local branch '$BRANCH' deleted."
+fi
+
+# Prune stale remote tracking refs
+git remote prune origin 2>/dev/null || true
+
 # --- Done ---
 echo ""
 echo "================================================"
 echo "  Shipped! PR #$PR_NUMBER merged to main."
+echo "  Branch '$BRANCH' deleted (local + remote)."
 echo "  $PR_URL"
 echo "================================================"

--- a/.claude/skills/approve-pr/SKILL.md
+++ b/.claude/skills/approve-pr/SKILL.md
@@ -2,7 +2,7 @@
 name: approve-pr
 description: Admin self-review gate — verifies all review issues are resolved then clears PR for merge
 argument-hint: [pr-number]
-disable-model-invocation: true
+disable-model-invocation: false
 allowed-tools: Bash, Read, AskUserQuestion
 ---
 

--- a/.claude/skills/create-pr/SKILL.md
+++ b/.claude/skills/create-pr/SKILL.md
@@ -2,7 +2,7 @@
 name: create-pr
 description: Create a new feature branch, PR, and folder structure for developing a new menu script
 argument-hint: [feature-name]
-disable-model-invocation: true
+disable-model-invocation: false
 allowed-tools: Bash, Read, Write, Edit, Glob, Grep, AskUserQuestion
 ---
 

--- a/.claude/skills/merge-pr/SKILL.md
+++ b/.claude/skills/merge-pr/SKILL.md
@@ -2,7 +2,7 @@
 name: merge-pr
 description: Check PR status, resolve issues, and merge a pull request
 argument-hint: [pr-number]
-disable-model-invocation: true
+disable-model-invocation: false
 allowed-tools: Bash, Read, AskUserQuestion
 ---
 

--- a/.claude/skills/pr-status/SKILL.md
+++ b/.claude/skills/pr-status/SKILL.md
@@ -2,7 +2,7 @@
 name: pr-status
 description: "Show open PRs and issues — summary or detailed view"
 argument-hint: "[pr-number | issue-number]"
-disable-model-invocation: true
+disable-model-invocation: false
 allowed-tools: Bash, Read
 ---
 

--- a/.claude/skills/review-tasks/SKILL.md
+++ b/.claude/skills/review-tasks/SKILL.md
@@ -2,7 +2,7 @@
 name: review-tasks
 description: Read code review comments from a PR and create todo tasks for each issue
 argument-hint: [pr-number]
-disable-model-invocation: true
+disable-model-invocation: false
 allowed-tools: Bash, Read, TaskCreate, TaskUpdate, TaskList, AskUserQuestion
 ---
 

--- a/.claude/skills/trigger-guardian/SKILL.md
+++ b/.claude/skills/trigger-guardian/SKILL.md
@@ -2,7 +2,7 @@
 name: trigger-guardian
 description: Trigger a Wiki Guardian test run by making a trivial wiki edit and checking the action result
 argument-hint: [optional: "spam" to test spam detection]
-disable-model-invocation: true
+disable-model-invocation: false
 allowed-tools: Bash, Read, AskUserQuestion
 ---
 


### PR DESCRIPTION
## Summary

- **merge-pr.sh** and **ship-it.sh** now delete the local branch and run `git remote prune origin` after merging — previously only the remote branch was deleted via `--delete-branch`
- Set `disable-model-invocation: false` on 6 skills (all except ship-it) so Claude can invoke them programmatically

## Test plan

- [ ] Run `/merge-pr` on a test PR — verify local branch is deleted and remote refs pruned
- [ ] Verify `/ship-it` still requires manual invocation (`disable-model-invocation: true`)
- [ ] Verify other skills can be invoked by Claude via the Skill tool

🤖 Generated with [Claude Code](https://claude.com/claude-code)