### PR TITLE
feat: add ComfyUI installer under new ai-tools category

### DIFF
--- a/mainmenu/llm/ai-tools/README.md
+++ b/mainmenu/llm/ai-tools/README.md
@@ -1,0 +1,26 @@
+# LLM AI Tools
+
+Standalone AI applications and frameworks for image generation, model serving, and more.
+
+## Scripts
+
+| Script | Description | Type |
+|--------|-------------|------|
+| ComfyUI | Node-based Stable Diffusion GUI and backend for image/video generation | install |
+
+## Quick Start
+
+```bash
+ninjamenu
+# Navigate to: Llm -> Ai-Tools -> ComfyUI
+```
+
+## Requirements
+
+- Internet connection for downloads
+- Python 3.12+ (installed automatically)
+- Sufficient disk space for models
+
+## Tags
+
+`llm` `ai-tools` `stable-diffusion` `image-generation` `comfyui`

--- a/mainmenu/llm/ai-tools/comfyui/_common.sh
+++ b/mainmenu/llm/ai-tools/comfyui/_common.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# Shared functions for ComfyUI installer — sourced by all OS scripts
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT_NAME="comfyui"
+MENU_ROOT="${MENU_ROOT:-$(cd "$SCRIPT_DIR" && while [[ ! -f "install_menu.sh" ]] && [[ "$PWD" != "/" ]]; do cd ..; done; pwd)}"
+source "$MENU_ROOT/.lib/platform.sh"
+
+LOG_DIR="$MENU_ROOT/.docs/logs"
+mkdir -p "$LOG_DIR"
+LOG_FILE="$LOG_DIR/${SCRIPT_NAME}_$(date +%Y%m%d_%H%M%S).log"
+
+# ── Shared config ─────────────────────────────────────────────────────────────
+COMFYUI_DIR="/opt/apps/LLM/ComfyUI"
+COMFYUI_REPO="https://github.com/comfyanonymous/ComfyUI.git"
+COMFYUI_MANAGER_REPO="https://github.com/ltdrdata/ComfyUI-Manager.git"
+PYTHON_VERSION="3.12"

--- a/mainmenu/llm/ai-tools/comfyui/macos.sh
+++ b/mainmenu/llm/ai-tools/comfyui/macos.sh
@@ -1,0 +1,109 @@
+#!/bin/bash
+# macOS implementation — do NOT add YAML headers here (use meta.yaml)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/_common.sh"
+
+exec > >(tee -a "$LOG_FILE") 2>&1
+
+# ── Install ──────────────────────────────────────────────────────────────────
+install() {
+    log_info "Installing ComfyUI on macOS..."
+    log_info "Log file: $LOG_FILE"
+
+    # Idempotency — skip if already installed
+    if [[ -f "$COMFYUI_DIR/main.py" ]]; then
+        log_info "ComfyUI already installed at $COMFYUI_DIR"
+        mark_installed true
+        return 0
+    fi
+
+    # Python 3.12 via Homebrew
+    if ! command -v "python${PYTHON_VERSION}" &>/dev/null; then
+        log_step "Installing Python ${PYTHON_VERSION} via Homebrew..."
+        brew install "python@${PYTHON_VERSION}"
+    else
+        log_info "Python ${PYTHON_VERSION} already installed"
+    fi
+
+    # Create parent directory
+    log_step "Creating install directory..."
+    sudo mkdir -p /opt/apps/LLM
+    sudo chown "$USER" /opt/apps/LLM
+
+    # Clone ComfyUI
+    log_step "Cloning ComfyUI repository..."
+    git clone "$COMFYUI_REPO" "$COMFYUI_DIR"
+
+    # Create virtual environment
+    log_step "Creating Python virtual environment..."
+    "python${PYTHON_VERSION}" -m venv "$COMFYUI_DIR/venv"
+
+    # Activate venv and install dependencies
+    source "$COMFYUI_DIR/venv/bin/activate"
+
+    log_step "Upgrading pip..."
+    pip install --upgrade pip
+
+    log_step "Installing PyTorch (MPS/Metal support)..."
+    pip install torch torchvision torchaudio
+
+    log_step "Installing ComfyUI requirements..."
+    pip install -r "$COMFYUI_DIR/requirements.txt"
+
+    # Install ComfyUI-Manager
+    log_step "Installing ComfyUI-Manager..."
+    git clone "$COMFYUI_MANAGER_REPO" "$COMFYUI_DIR/custom_nodes/ComfyUI-Manager"
+    if [[ -f "$COMFYUI_DIR/custom_nodes/ComfyUI-Manager/requirements.txt" ]]; then
+        pip install -r "$COMFYUI_DIR/custom_nodes/ComfyUI-Manager/requirements.txt"
+    fi
+
+    # Verify installation
+    log_step "Verifying installation..."
+    cd "$COMFYUI_DIR"
+    python main.py --quick-test-for-ci
+
+    deactivate
+
+    echo ""
+    log_success "ComfyUI installed successfully!"
+    echo ""
+    echo "  Location: $COMFYUI_DIR"
+    echo "  To run:   source $COMFYUI_DIR/venv/bin/activate && python $COMFYUI_DIR/main.py"
+    echo "  Web UI:   http://127.0.0.1:8188"
+    echo ""
+
+    mark_installed true
+}
+
+# ── Uninstall ────────────────────────────────────────────────────────────────
+uninstall() {
+    log_info "Removing ComfyUI..."
+
+    if [[ ! -d "$COMFYUI_DIR" ]]; then
+        log_info "ComfyUI not found at $COMFYUI_DIR — nothing to remove"
+        mark_installed false
+        return 0
+    fi
+
+    echo ""
+    read -rp "Remove $COMFYUI_DIR and all models/data? [y/N] " confirm
+    if [[ "$confirm" != [yY] ]]; then
+        log_info "Uninstall cancelled"
+        return 0
+    fi
+
+    rm -rf "$COMFYUI_DIR"
+    log_success "ComfyUI removed"
+    mark_installed false
+}
+
+ACTION="${1:-install}"
+
+case "$ACTION" in
+    install) install ;;
+    uninstall) uninstall ;;
+    *) echo "Usage: $0 {install|uninstall}"; exit 1 ;;
+esac

--- a/mainmenu/llm/ai-tools/comfyui/meta.yaml
+++ b/mainmenu/llm/ai-tools/comfyui/meta.yaml
@@ -1,0 +1,19 @@
+name: "ComfyUI"
+description: "Node-based Stable Diffusion GUI and backend for image/video generation"
+version: "1.0.0"
+author: "comfyanonymous"
+root: false
+order: 20
+hidden: false
+installed: false
+check_path: "/opt/apps/LLM/ComfyUI/main.py"
+supported_os:
+  - macos
+dependencies:
+  - git
+  - brew
+tags:
+  - llm
+  - stable-diffusion
+  - image-generation
+  - comfyui


### PR DESCRIPTION
## Summary
- Creates new `mainmenu/llm/ai-tools/` category subfolder for standalone AI applications
- Moves ComfyUI installer into `ai-tools/comfyui/` so it follows the convention of sitting inside a category folder (not directly under a top-level menu alongside other category folders)
- Adds README for the new ai-tools category

## Test plan
- [ ] Launch menu → LLM → verify "Ai-Tools" appears as a `📁` folder
- [ ] Enter Ai-Tools → verify ComfyUI appears as `⬜` (not installed)
- [ ] Verify ComfyUI no longer appears at the top-level LLM menu

🤖 Generated with [Claude Code](https://claude.com/claude-code)