### PR TITLE
feat: add category.yaml descriptions to submenu folders

### DIFF
--- a/.app/cache.py
+++ b/.app/cache.py
@@ -65,7 +65,8 @@ CREATE TABLE IF NOT EXISTS submenus (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     path TEXT UNIQUE NOT NULL,
     name TEXT NOT NULL,
-    parent_menu TEXT NOT NULL
+    parent_menu TEXT NOT NULL,
+    description TEXT NOT NULL DEFAULT ''
 );
 
 CREATE TABLE IF NOT EXISTS alias_entries (
@@ -195,6 +196,14 @@ def rebuild_cache(menu_dir: Path, db_path: Path) -> None:
     conn.execute("PRAGMA journal_mode=WAL")
     conn.execute("PRAGMA foreign_keys=ON")
 
+    # Migrate: drop submenus table if it lacks the description column
+    try:
+        cols = {row[1] for row in conn.execute("PRAGMA table_info(submenus)").fetchall()}
+        if cols and 'description' not in cols:
+            conn.execute("DROP TABLE IF EXISTS submenus")
+    except Exception:
+        pass
+
     # Create schema (idempotent)
     conn.executescript(_SCHEMA)
 
@@ -232,9 +241,16 @@ def _walk_and_insert(directory: Path, menu_root: Path, conn: sqlite3.Connection)
                 rel_path = str(entry.relative_to(menu_root))
                 name_parts = entry.name.replace('-', ' ').replace('_', ' ').split()
                 camel_name = ''.join(word.capitalize() for word in name_parts)
+
+                # Check for category.yaml with display name/description
+                cat_yaml = entry / "category.yaml"
+                cat_data = _parse_yaml_file(cat_yaml) if cat_yaml.exists() else None
+                display_name = cat_data.get('name', camel_name) if cat_data else camel_name
+                description = cat_data.get('description', '') if cat_data else ''
+
                 conn.execute(
-                    "INSERT OR REPLACE INTO submenus (path, name, parent_menu) VALUES (?, ?, ?)",
-                    (rel_path, camel_name, parent_menu)
+                    "INSERT OR REPLACE INTO submenus (path, name, parent_menu, description) VALUES (?, ?, ?, ?)",
+                    (rel_path, display_name, parent_menu, description)
                 )
                 # Recurse into submenu
                 _walk_and_insert(entry, menu_root, conn)
@@ -387,10 +403,10 @@ def is_cache_stale(menu_dir: Path, db_path: Path) -> bool:
         return True
 
     # Walk filesystem and compare
-    return _check_staleness(menu_dir, menu_dir, cached)
+    return _check_staleness(menu_dir, menu_root=menu_dir, cached=cached, db_mtime=db_path.stat().st_mtime)
 
 
-def _check_staleness(directory: Path, menu_root: Path, cached: Dict[str, float]) -> bool:
+def _check_staleness(directory: Path, menu_root: Path, cached: Dict[str, float], db_mtime: float = 0) -> bool:
     """Recursively check if any meta file has changed."""
     if not directory.exists():
         return False
@@ -407,7 +423,12 @@ def _check_staleness(directory: Path, menu_root: Path, cached: Dict[str, float])
                 if rel_path not in cached or cached[rel_path] != current_mtime:
                     return True
             else:
-                if _check_staleness(entry, menu_root, cached):
+                # Check if category.yaml is newer than the cache db
+                cat_yaml = entry / "category.yaml"
+                if cat_yaml.exists():
+                    if cat_yaml.stat().st_mtime > db_mtime:
+                        return True
+                if _check_staleness(entry, menu_root, cached, db_mtime):
                     return True
         elif entry.suffix == '.sh':
             sibling_meta = entry.parent / f"{entry.stem}.meta.yaml"
@@ -439,7 +460,7 @@ def get_menu_items(db_path: Path, parent_menu: str, current_os: str) -> List[Dic
 
     # 1. Submenus
     rows = conn.execute(
-        "SELECT path, name FROM submenus WHERE parent_menu = ? ORDER BY name",
+        "SELECT path, name, description FROM submenus WHERE parent_menu = ? ORDER BY name",
         (parent_menu,)
     ).fetchall()
     for row in rows:
@@ -447,6 +468,7 @@ def get_menu_items(db_path: Path, parent_menu: str, current_os: str) -> List[Dic
             'is_submenu': True,
             'path': row['path'],
             'name': row['name'],
+            'description': row['description'],
             'order': 0,
         })
 

--- a/.app/menu.py
+++ b/.app/menu.py
@@ -452,6 +452,7 @@ class MenuItem:
     is_submenu: bool = False
     script_info: Optional[ScriptInfo] = None
     order: int = 50
+    description: str = ""
 
 
 def parse_yaml_header(script_path: Path) -> Optional[ScriptInfo]:
@@ -649,6 +650,7 @@ def scan_menu_directory(directory: Path) -> List[MenuItem]:
                 path=MAIN_MENU_DIR / d['path'],
                 is_submenu=True,
                 order=0,
+                description=d.get('description', ''),
             ))
         else:
             script_info = _dict_to_script_info(d)
@@ -1725,7 +1727,10 @@ def gum_menu(directory: Path, breadcrumb: List[str] = None) -> None:
             # Zero-padded prefix for display, but also map non-padded for easy typing
             padded = str(num).zfill(pad_width)
             if item.is_submenu:
-                label = f"{padded}. 📁 {item.name}"
+                if item.description:
+                    label = f"{padded}. 📁 {item.name} — {item.description}"
+                else:
+                    label = f"{padded}. 📁 {item.name}"
             else:
                 if item.script_info.script_type == "tool":
                     if item.script_info.binary and not item.script_info.binary_available:
@@ -1995,7 +2000,10 @@ def whiptail_menu(directory: Path, breadcrumb: List[str] = None) -> None:
         for i, item in enumerate(items):
             tag = str(i + 1)  # 1-based numbering shown as tag
             if item.is_submenu:
-                desc = f"📁 {item.name}"
+                if item.description:
+                    desc = f"📁 {item.name} — {item.description}"
+                else:
+                    desc = f"📁 {item.name}"
             else:
                 status = "✅" if item.script_info.installed else "⬜"
                 root = "🔐" if item.script_info.root else ""
@@ -2271,7 +2279,10 @@ if HAS_TEXTUAL:
                 opt_id = f"item_{idx}"
                 self._id_to_item[opt_id] = item
                 if item.is_submenu:
-                    option_list.add_option(Option(f"{folder_num}. 📁 {item.name}", id=opt_id))
+                    if item.description:
+                        option_list.add_option(Option(f"{folder_num}. 📁 {item.name} — {item.description}", id=opt_id))
+                    else:
+                        option_list.add_option(Option(f"{folder_num}. 📁 {item.name}", id=opt_id))
                     folder_num += 1
                 else:
                     status = "✅" if item.script_info.installed else "⬜"
@@ -2303,7 +2314,8 @@ if HAS_TEXTUAL:
                     status = "✅ Installed" if info.installed else "⬜ Not installed"
                     info_panel.update(f"{info.description}\n[{status}{root}{tags}]")
             elif item and item.is_submenu:
-                info_panel.update(f"📁 {item.name}\nPress Enter to open submenu")
+                desc = f"\n{item.description}" if item.description else ""
+                info_panel.update(f"📁 {item.name}{desc}\nPress Enter to open submenu")
             else:
                 info_panel.update("Use ↑↓ arrows to navigate, Enter to select, Backspace/Esc to go back, q to quit")
 
@@ -2448,7 +2460,10 @@ def list_all_scripts(directory: Path = None, indent: int = 0) -> None:
 
     for item in items:
         if item.is_submenu:
-            print(f"{prefix}📁 {item.name}/")
+            if item.description:
+                print(f"{prefix}📁 {item.name}/ — {item.description}")
+            else:
+                print(f"{prefix}📁 {item.name}/")
             list_all_scripts(item.path, indent + 1)
         else:
             info = item.script_info

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -218,11 +218,16 @@ When adding a new script or folder:
 
 1. Create a new folder under the parent menu (this becomes a `📁` category in the menu)
 2. **Every top-level menu section must use category subfolders** — scripts are never placed alongside subfolder siblings. A folder either contains only subfolders (category) or only scripts (leaf), never both.
-3. Create README.md from template
-4. Create user manual in `.docs/user_manuals/{folder}.md`
-5. Create technical manual in `.docs/technical_manuals/{folder}.md`
-6. Add scripts to the folder
-7. Menu system auto-discovers on next run
+3. Add a `category.yaml` file with a display `name` and `description` (both optional — without it, the folder name is titlecased and no description is shown):
+   ```yaml
+   name: "CLI Tools"
+   description: "Command-line LLM interfaces and chatbots"
+   ```
+4. Create README.md from template
+5. Create user manual in `.docs/user_manuals/{folder}.md`
+6. Create technical manual in `.docs/technical_manuals/{folder}.md`
+7. Add scripts to the folder
+8. Menu system auto-discovers on next run
 
 ### Logging
 

--- a/mainmenu/CONTRIBUTING.md
+++ b/mainmenu/CONTRIBUTING.md
@@ -15,6 +15,17 @@ Full technical reference: [`.docs/technical_manuals/os-modular-architecture.md`]
 
 A folder is either a **category** (contains only subfolders) or a **leaf** (contains only scripts) — never both.
 
+### Category Metadata (`category.yaml`)
+
+Submenu folders can include an optional `category.yaml` to set a display name and description shown in the menu:
+
+```yaml
+name: "CLI Tools"
+description: "Command-line LLM interfaces and chatbots"
+```
+
+Both fields are optional. Without `category.yaml`, the folder name is titlecased (e.g. `cli` → `Cli`) and no description is shown.
+
 ## Quick Decision: Which Tier?
 
 - **Does the script need different code per OS?** → **Tier 1** (modular folder)

--- a/mainmenu/editors/category.yaml
+++ b/mainmenu/editors/category.yaml
@@ -1,0 +1,2 @@
+name: "Editors"
+description: "Text editors and IDE installers"

--- a/mainmenu/editors/obsidian/category.yaml
+++ b/mainmenu/editors/obsidian/category.yaml
@@ -1,0 +1,2 @@
+name: "Obsidian"
+description: "Obsidian knowledge base and plugins"

--- a/mainmenu/education/category.yaml
+++ b/mainmenu/education/category.yaml
@@ -1,0 +1,2 @@
+name: "Education"
+description: "Security training and learning tools"

--- a/mainmenu/education/network/category.yaml
+++ b/mainmenu/education/network/category.yaml
@@ -1,0 +1,2 @@
+name: "Network"
+description: "Network security education scripts"

--- a/mainmenu/education/network/nmap-unleashed/category.yaml
+++ b/mainmenu/education/network/nmap-unleashed/category.yaml
@@ -1,0 +1,2 @@
+name: "Nmap Unleashed"
+description: "Advanced Nmap techniques and scripts"

--- a/mainmenu/education/network/nmap-unleashed/reporting/category.yaml
+++ b/mainmenu/education/network/nmap-unleashed/reporting/category.yaml
@@ -1,0 +1,2 @@
+name: "Reporting"
+description: "Scan result reporting and analysis"

--- a/mainmenu/education/network/nmap-unleashed/scanning/category.yaml
+++ b/mainmenu/education/network/nmap-unleashed/scanning/category.yaml
@@ -1,0 +1,2 @@
+name: "Scanning"
+description: "Advanced scanning techniques"

--- a/mainmenu/education/network/nmap/category.yaml
+++ b/mainmenu/education/network/nmap/category.yaml
@@ -1,0 +1,2 @@
+name: "Nmap"
+description: "Nmap scanning tutorials and exercises"

--- a/mainmenu/education/network/nmap/discovery/category.yaml
+++ b/mainmenu/education/network/nmap/discovery/category.yaml
@@ -1,0 +1,2 @@
+name: "Discovery"
+description: "Host discovery and ping scanning techniques"

--- a/mainmenu/education/network/nmap/evasion/category.yaml
+++ b/mainmenu/education/network/nmap/evasion/category.yaml
@@ -1,0 +1,2 @@
+name: "Evasion"
+description: "Firewall and IDS evasion techniques"

--- a/mainmenu/education/network/nmap/footprinting/category.yaml
+++ b/mainmenu/education/network/nmap/footprinting/category.yaml
@@ -1,0 +1,2 @@
+name: "Footprinting"
+description: "OS and service fingerprinting methods"

--- a/mainmenu/education/network/nmap/output/category.yaml
+++ b/mainmenu/education/network/nmap/output/category.yaml
@@ -1,0 +1,2 @@
+name: "Output"
+description: "Scan output formats and reporting"

--- a/mainmenu/education/network/nmap/scanning/category.yaml
+++ b/mainmenu/education/network/nmap/scanning/category.yaml
@@ -1,0 +1,2 @@
+name: "Scanning"
+description: "Port scanning techniques and methods"

--- a/mainmenu/education/network/nmap/vulnerability/category.yaml
+++ b/mainmenu/education/network/nmap/vulnerability/category.yaml
@@ -1,0 +1,2 @@
+name: "Vulnerability"
+description: "Vulnerability detection with NSE scripts"

--- a/mainmenu/git/category.yaml
+++ b/mainmenu/git/category.yaml
@@ -1,0 +1,2 @@
+name: "Git"
+description: "Git setup and repository management"

--- a/mainmenu/llm/ai-tools/category.yaml
+++ b/mainmenu/llm/ai-tools/category.yaml
@@ -1,0 +1,2 @@
+name: "AI Tools"
+description: "Standalone AI apps for image and video generation"

--- a/mainmenu/llm/category.yaml
+++ b/mainmenu/llm/category.yaml
@@ -1,0 +1,2 @@
+name: "LLM"
+description: "Large language model tools and integrations"

--- a/mainmenu/llm/claude/category.yaml
+++ b/mainmenu/llm/claude/category.yaml
@@ -1,0 +1,2 @@
+name: "Claude"
+description: "Anthropic Claude setup and extensions"

--- a/mainmenu/llm/cli/category.yaml
+++ b/mainmenu/llm/cli/category.yaml
@@ -1,0 +1,2 @@
+name: "CLI Tools"
+description: "Command-line LLM interfaces and chatbots"

--- a/mainmenu/llm/ide/category.yaml
+++ b/mainmenu/llm/ide/category.yaml
@@ -1,0 +1,2 @@
+name: "IDE"
+description: "AI-powered code editors and development environments"

--- a/mainmenu/llm/mcp/category.yaml
+++ b/mainmenu/llm/mcp/category.yaml
@@ -1,0 +1,2 @@
+name: "MCP"
+description: "Model Context Protocol server installers"

--- a/mainmenu/monitoring/category.yaml
+++ b/mainmenu/monitoring/category.yaml
@@ -1,0 +1,2 @@
+name: "Monitoring"
+description: "System monitoring and process management"

--- a/mainmenu/network/category.yaml
+++ b/mainmenu/network/category.yaml
@@ -1,0 +1,2 @@
+name: "Network"
+description: "Network analysis and security tools"

--- a/mainmenu/postsetup-kali/category.yaml
+++ b/mainmenu/postsetup-kali/category.yaml
@@ -1,0 +1,2 @@
+name: "Post-Setup Kali"
+description: "Kali Linux post-installation configuration"

--- a/mainmenu/proxmox/category.yaml
+++ b/mainmenu/proxmox/category.yaml
@@ -1,0 +1,2 @@
+name: "Proxmox"
+description: "Proxmox VE virtualisation platform setup"


### PR DESCRIPTION
## Summary
- Submenu folders now support an optional `category.yaml` file with `name` and `description` fields
- Descriptions are shown alongside folder names in all menu backends (gum, whiptail, textual, list view)
- Created 25 `category.yaml` files for all existing submenu folders
- Added schema migration, staleness detection for `category.yaml`, and updated docs

## Test plan
- [ ] Run `menu.py --rebuild` — cache rebuilds without errors
- [ ] Launch menu — top-level shows descriptions next to folder names
- [ ] Enter a subfolder — nested submenus also show descriptions
- [ ] Remove a `category.yaml` — folder falls back to titlecased name, no description
- [ ] Edit a `category.yaml` — re-launch triggers auto-rebuild with updated description

🤖 Generated with [Claude Code](https://claude.com/claude-code)