### PR TITLE
feat: Docker, Podman, and Portainer runtime

### DIFF
--- a/mainmenu/containers/README.md
+++ b/mainmenu/containers/README.md
@@ -1,0 +1,25 @@
+# Containers
+
+Container runtimes and orchestration tools.
+
+## Categories
+
+| Category | Description |
+|----------|-------------|
+| [Runtime](runtime/) | Container engines and management UIs |
+
+## Quick Start
+
+```bash
+ninjamenu
+# Navigate to: Containers -> Runtime -> pick a tool
+```
+
+## Documentation
+
+- [User Guide](../../.docs/user_manuals/containers.md) - Usage instructions
+- [Technical Manual](../../.docs/technical_manuals/containers.md) - Developer docs
+
+## Tags
+
+`containers` `docker` `podman` `portainer`

--- a/mainmenu/containers/category.yaml
+++ b/mainmenu/containers/category.yaml
@@ -1,0 +1,2 @@
+name: "Containers"
+description: "Container runtimes and orchestration"

--- a/mainmenu/containers/runtime/README.md
+++ b/mainmenu/containers/runtime/README.md
@@ -1,0 +1,56 @@
+# Container Runtime
+
+Container engines and management UIs.
+
+## Scripts
+
+| Script | Description | Type |
+|--------|-------------|------|
+| Docker CE | Full Docker Community Edition with Compose and Buildx plugins | install |
+| Podman | Rootless container engine — daemonless Docker alternative | install |
+| Portainer CE | Web-based Docker management UI running as a container | install |
+
+## Quick Start
+
+```bash
+ninjamenu
+# Navigate to: Containers -> Runtime -> pick a tool
+```
+
+## Included Tools
+
+### Docker CE
+Full Docker Community Edition installation including:
+- Docker engine, CLI, containerd
+- Buildx and Compose plugins
+- Docker group configuration
+- Custom data directory at `/opt/app/docker`
+
+### Podman
+Rootless container engine as a Docker alternative:
+- Daemonless architecture
+- Rootless container support with slirp4netns
+- Custom storage at `/opt/app/podman`
+- User socket for API compatibility
+
+### Portainer CE
+Web-based management UI for Docker:
+- Runs as a Docker container on port 9443
+- Persistent data volume
+- Optional systemd service integration
+- Manages containers, images, volumes, networks
+
+## Requirements
+
+- Root access for Docker and Podman installation
+- Docker must be installed before Portainer
+- Debian/Ubuntu-based distributions
+
+## Documentation
+
+- [User Guide](../../../.docs/user_manuals/containers.md) - Usage instructions
+- [Technical Manual](../../../.docs/technical_manuals/containers.md) - Developer docs
+
+## Tags
+
+`containers` `docker` `podman` `portainer` `runtime`

--- a/mainmenu/containers/runtime/category.yaml
+++ b/mainmenu/containers/runtime/category.yaml
@@ -1,0 +1,2 @@
+name: "Runtime"
+description: "Container engines and management UIs"

--- a/mainmenu/containers/runtime/docker.meta.yaml
+++ b/mainmenu/containers/runtime/docker.meta.yaml
@@ -1,0 +1,18 @@
+name: "Docker CE"
+description: "Full Docker Community Edition with Compose and Buildx plugins"
+version: "1.0.0"
+author: "System"
+type: install
+root: true
+order: 10
+hidden: false
+installed: false
+check_command: "docker --version"
+tags:
+  - containers
+  - docker
+  - runtime
+supported_os:
+  - kali
+  - debian
+  - ubuntu

--- a/mainmenu/containers/runtime/docker.sh
+++ b/mainmenu/containers/runtime/docker.sh
@@ -1,0 +1,137 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT_NAME="docker"
+MENU_ROOT="${MENU_ROOT:-$(cd "$SCRIPT_DIR" && while [[ ! -f "install_menu.sh" ]] && [[ "$PWD" != "/" ]]; do cd ..; done; pwd)}"
+source "$MENU_ROOT/.lib/platform.sh"
+
+LOG_DIR="$MENU_ROOT/.docs/logs"
+mkdir -p "$LOG_DIR"
+LOG_FILE="$LOG_DIR/${SCRIPT_NAME}_$(date +%Y%m%d_%H%M%S).log"
+exec > >(tee -a "$LOG_FILE") 2>&1
+
+DATA_ROOT="/opt/app/docker"
+
+install() {
+    log_info "Installing Docker CE"
+    log_info "Log file: $LOG_FILE"
+    echo ""
+
+    require_root
+
+    # Step 1: Remove old/conflicting packages
+    log_step "Removing old Docker packages if present..."
+    local OLD_PKGS=(docker.io docker-doc docker-compose podman-docker containerd runc)
+    for pkg in "${OLD_PKGS[@]}"; do
+        apt-get remove -y "$pkg" 2>/dev/null || true
+    done
+
+    # Step 2: Install prerequisites
+    log_step "Installing prerequisites..."
+    pkg_update
+    pkg_install ca-certificates curl gnupg
+
+    # Step 3: Add Docker GPG key
+    log_step "Adding Docker's official GPG key..."
+    install -m 0755 -d /etc/apt/keyrings
+    if [[ -f /etc/apt/keyrings/docker.gpg ]]; then
+        rm -f /etc/apt/keyrings/docker.gpg
+    fi
+    curl -fsSL https://download.docker.com/linux/$(. /etc/os-release && echo "$ID")/gpg | \
+        gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+    chmod a+r /etc/apt/keyrings/docker.gpg
+
+    # Step 4: Add Docker apt repository
+    log_step "Adding Docker apt repository..."
+    echo \
+        "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] \
+        https://download.docker.com/linux/$(. /etc/os-release && echo "$ID") \
+        $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | \
+        tee /etc/apt/sources.list.d/docker.list > /dev/null
+    apt-get update
+
+    # Step 5: Install Docker CE and plugins
+    log_step "Installing Docker CE, CLI, containerd, Buildx, and Compose..."
+    apt-get install -y \
+        docker-ce \
+        docker-ce-cli \
+        containerd.io \
+        docker-buildx-plugin \
+        docker-compose-plugin
+
+    # Step 6: Create docker group
+    log_step "Creating docker group..."
+    groupadd docker || true
+
+    # Step 7: Add current user to docker group
+    REAL_USER="${SUDO_USER:-$USER}"
+    log_step "Adding user '${REAL_USER}' to docker group..."
+    usermod -aG docker "$REAL_USER"
+
+    # Step 8: Configure data directory
+    log_step "Configuring Docker data root at ${DATA_ROOT}..."
+    mkdir -p "$DATA_ROOT"
+
+    cat > /etc/docker/daemon.json <<JSON
+{
+    "data-root": "${DATA_ROOT}",
+    "log-driver": "json-file",
+    "log-opts": {
+        "max-size": "10m",
+        "max-file": "3"
+    }
+}
+JSON
+
+    # Step 9: Enable and start Docker
+    log_step "Enabling and starting Docker service..."
+    systemctl enable --now docker
+
+    # Step 10: Verify
+    log_step "Verifying installation..."
+    docker --version
+    docker compose version
+
+    echo ""
+    log_success "Docker CE installed successfully."
+    log_info "Data directory: ${DATA_ROOT}"
+    log_info ""
+    log_info "IMPORTANT: Log out and back in for docker group membership to take effect."
+    log_info "Then test with: docker run hello-world"
+    mark_installed true
+}
+
+uninstall() {
+    log_info "Uninstalling Docker CE"
+    require_root
+
+    log_step "Stopping Docker service..."
+    systemctl stop docker 2>/dev/null || true
+    systemctl stop docker.socket 2>/dev/null || true
+    systemctl disable docker 2>/dev/null || true
+
+    log_step "Removing Docker packages..."
+    apt-get purge -y docker-ce docker-ce-cli containerd.io \
+        docker-buildx-plugin docker-compose-plugin 2>/dev/null || true
+    apt-get autoremove -y 2>/dev/null || true
+
+    log_step "Removing Docker apt repository and GPG key..."
+    rm -f /etc/apt/sources.list.d/docker.list
+    rm -f /etc/apt/keyrings/docker.gpg
+
+    echo ""
+    log_info "Docker data directory at ${DATA_ROOT} has NOT been removed."
+    log_info "To remove all Docker data: sudo rm -rf ${DATA_ROOT}"
+    log_info "To remove config: sudo rm -f /etc/docker/daemon.json"
+
+    echo ""
+    log_success "Docker CE uninstalled."
+    mark_installed false
+}
+
+case "${1:-install}" in
+    install) install ;;
+    uninstall) uninstall ;;
+    *) echo "Usage: $0 {install|uninstall}"; exit 1 ;;
+esac

--- a/mainmenu/containers/runtime/podman.meta.yaml
+++ b/mainmenu/containers/runtime/podman.meta.yaml
@@ -1,0 +1,19 @@
+name: "Podman"
+description: "Rootless container engine — daemonless Docker alternative"
+version: "1.0.0"
+author: "System"
+type: install
+root: true
+order: 20
+hidden: false
+installed: false
+check_command: "podman --version"
+tags:
+  - containers
+  - podman
+  - rootless
+  - runtime
+supported_os:
+  - kali
+  - debian
+  - ubuntu

--- a/mainmenu/containers/runtime/podman.sh
+++ b/mainmenu/containers/runtime/podman.sh
@@ -1,0 +1,100 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT_NAME="podman"
+MENU_ROOT="${MENU_ROOT:-$(cd "$SCRIPT_DIR" && while [[ ! -f "install_menu.sh" ]] && [[ "$PWD" != "/" ]]; do cd ..; done; pwd)}"
+source "$MENU_ROOT/.lib/platform.sh"
+
+LOG_DIR="$MENU_ROOT/.docs/logs"
+mkdir -p "$LOG_DIR"
+LOG_FILE="$LOG_DIR/${SCRIPT_NAME}_$(date +%Y%m%d_%H%M%S).log"
+exec > >(tee -a "$LOG_FILE") 2>&1
+
+STORAGE_ROOT="/opt/app/podman"
+STORAGE_CONF="/etc/containers/storage.conf"
+
+install() {
+    log_info "Installing Podman (rootless container engine)"
+    log_info "Log file: $LOG_FILE"
+    echo ""
+
+    require_root
+
+    # Step 1: Install podman
+    log_step "Installing podman..."
+    pkg_update
+    pkg_install podman
+
+    # Step 2: Install rootless dependencies
+    log_step "Installing rootless prerequisites (slirp4netns, fuse-overlayfs)..."
+    pkg_install slirp4netns fuse-overlayfs uidmap
+
+    # Step 3: Configure storage
+    log_step "Configuring container storage at ${STORAGE_ROOT}..."
+    mkdir -p "$STORAGE_ROOT"
+    mkdir -p "$(dirname "$STORAGE_CONF")"
+
+    # Back up existing config if present
+    if [[ -f "$STORAGE_CONF" ]]; then
+        cp "$STORAGE_CONF" "${STORAGE_CONF}.bak.$(date +%Y%m%d_%H%M%S)"
+    fi
+
+    cat > "$STORAGE_CONF" <<CONF
+[storage]
+driver = "overlay"
+graphroot = "${STORAGE_ROOT}"
+
+[storage.options]
+mount_program = "/usr/bin/fuse-overlayfs"
+
+[storage.options.overlay]
+mount_program = "/usr/bin/fuse-overlayfs"
+CONF
+
+    # Step 4: Enable podman socket for the invoking user
+    REAL_USER="${SUDO_USER:-$USER}"
+    log_step "Enabling podman socket for user '${REAL_USER}'..."
+    if command -v loginctl &>/dev/null; then
+        loginctl enable-linger "$REAL_USER" 2>/dev/null || true
+    fi
+    # The user socket must be enabled by the user themselves
+    log_info "To enable the podman user socket, run as ${REAL_USER}:"
+    log_info "  systemctl --user enable --now podman.socket"
+
+    # Step 5: Verify
+    log_step "Verifying installation..."
+    podman --version
+    podman info --format '{{.Host.OCIRuntime.Name}}' 2>/dev/null || true
+
+    echo ""
+    log_success "Podman installed successfully."
+    log_info "Storage root: ${STORAGE_ROOT}"
+    log_info ""
+    log_info "Test with: podman run --rm docker.io/library/hello-world"
+    mark_installed true
+}
+
+uninstall() {
+    log_info "Uninstalling Podman"
+    require_root
+
+    log_step "Removing podman packages..."
+    pkg_remove podman
+    apt-get autoremove -y 2>/dev/null || true
+
+    echo ""
+    log_info "Podman storage at ${STORAGE_ROOT} has NOT been removed."
+    log_info "To remove all data: sudo rm -rf ${STORAGE_ROOT}"
+    log_info "To remove config: sudo rm -f ${STORAGE_CONF}"
+
+    echo ""
+    log_success "Podman uninstalled."
+    mark_installed false
+}
+
+case "${1:-install}" in
+    install) install ;;
+    uninstall) uninstall ;;
+    *) echo "Usage: $0 {install|uninstall}"; exit 1 ;;
+esac

--- a/mainmenu/containers/runtime/portainer.meta.yaml
+++ b/mainmenu/containers/runtime/portainer.meta.yaml
@@ -1,0 +1,20 @@
+name: "Portainer CE"
+description: "Web-based Docker management UI running as a container"
+version: "1.0.0"
+author: "System"
+type: install
+root: false
+order: 30
+hidden: false
+installed: false
+check_command: "docker ps --filter name=portainer --format '{{.Names}}' 2>/dev/null | grep -q portainer"
+tags:
+  - containers
+  - portainer
+  - docker
+  - management
+  - webui
+supported_os:
+  - kali
+  - debian
+  - ubuntu

--- a/mainmenu/containers/runtime/portainer.sh
+++ b/mainmenu/containers/runtime/portainer.sh
@@ -1,0 +1,131 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT_NAME="portainer"
+MENU_ROOT="${MENU_ROOT:-$(cd "$SCRIPT_DIR" && while [[ ! -f "install_menu.sh" ]] && [[ "$PWD" != "/" ]]; do cd ..; done; pwd)}"
+source "$MENU_ROOT/.lib/platform.sh"
+
+LOG_DIR="$MENU_ROOT/.docs/logs"
+mkdir -p "$LOG_DIR"
+LOG_FILE="$LOG_DIR/${SCRIPT_NAME}_$(date +%Y%m%d_%H%M%S).log"
+exec > >(tee -a "$LOG_FILE") 2>&1
+
+CONTAINER_NAME="portainer"
+VOLUME_NAME="portainer_data"
+IMAGE="portainer/portainer-ce:lts"
+
+install() {
+    log_info "Installing Portainer CE (Docker management UI)"
+    log_info "Log file: $LOG_FILE"
+    echo ""
+
+    # Check Docker is available
+    if ! command -v docker &>/dev/null; then
+        log_error "Docker is not installed. Install Docker first from the menu."
+        exit 1
+    fi
+
+    if ! docker info &>/dev/null; then
+        log_error "Docker daemon is not running or current user lacks permissions."
+        log_error "Ensure Docker is running and your user is in the 'docker' group."
+        exit 1
+    fi
+
+    # Remove existing container if present
+    if docker ps -a --filter "name=${CONTAINER_NAME}" --format '{{.Names}}' | grep -q "${CONTAINER_NAME}"; then
+        log_step "Removing existing Portainer container..."
+        docker stop "${CONTAINER_NAME}" 2>/dev/null || true
+        docker rm "${CONTAINER_NAME}" 2>/dev/null || true
+    fi
+
+    # Step 1: Create volume
+    log_step "Creating Docker volume '${VOLUME_NAME}'..."
+    docker volume create "${VOLUME_NAME}"
+
+    # Step 2: Pull and run Portainer
+    log_step "Pulling and starting Portainer CE..."
+    docker run -d \
+        -p 9443:9443 \
+        --name "${CONTAINER_NAME}" \
+        --restart=always \
+        -v /var/run/docker.sock:/var/run/docker.sock \
+        -v "${VOLUME_NAME}:/data" \
+        "${IMAGE}"
+
+    # Step 3: Create systemd service (optional, for host-level management)
+    log_step "Creating systemd service unit..."
+    if [[ -w /etc/systemd/system/ ]]; then
+        cat > /etc/systemd/system/portainer.service <<SERVICE
+[Unit]
+Description=Portainer CE Container
+Requires=docker.service
+After=docker.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/bin/docker start ${CONTAINER_NAME}
+ExecStop=/usr/bin/docker stop ${CONTAINER_NAME}
+
+[Install]
+WantedBy=multi-user.target
+SERVICE
+        systemctl daemon-reload
+        systemctl enable portainer.service 2>/dev/null || true
+        log_info "Systemd service created and enabled."
+    else
+        log_info "Skipping systemd service (no write access to /etc/systemd/system/)."
+        log_info "Portainer will auto-restart via Docker's --restart=always policy."
+    fi
+
+    # Step 4: Verify
+    log_step "Verifying Portainer is running..."
+    sleep 3
+    if docker ps --filter "name=${CONTAINER_NAME}" --format '{{.Status}}' | grep -q "Up"; then
+        log_success "Portainer CE is running."
+    else
+        log_error "Portainer container may not have started correctly."
+        docker logs "${CONTAINER_NAME}" --tail 20
+    fi
+
+    echo ""
+    log_success "Portainer CE installed successfully."
+    log_info "Access the web UI at: https://localhost:9443"
+    log_info "On first visit, create your admin user."
+    mark_installed true
+}
+
+uninstall() {
+    log_info "Uninstalling Portainer CE"
+
+    if ! command -v docker &>/dev/null; then
+        log_error "Docker is not installed."
+        exit 1
+    fi
+
+    log_step "Stopping and removing Portainer container..."
+    docker stop "${CONTAINER_NAME}" 2>/dev/null || true
+    docker rm "${CONTAINER_NAME}" 2>/dev/null || true
+
+    log_step "Removing Portainer volume..."
+    docker volume rm "${VOLUME_NAME}" 2>/dev/null || true
+
+    # Remove systemd service if it exists
+    if [[ -f /etc/systemd/system/portainer.service ]]; then
+        log_step "Removing systemd service..."
+        systemctl disable portainer.service 2>/dev/null || true
+        rm -f /etc/systemd/system/portainer.service
+        systemctl daemon-reload 2>/dev/null || true
+    fi
+
+    echo ""
+    log_success "Portainer CE uninstalled."
+    mark_installed false
+}
+
+case "${1:-install}" in
+    install) install ;;
+    uninstall) uninstall ;;
+    *) echo "Usage: $0 {install|uninstall}"; exit 1 ;;
+esac


### PR DESCRIPTION
## Summary
- New `containers/` top-level category with `runtime/` subcategory
- Docker CE with docker group (non-root), `/opt/app/docker` data root, systemd
- Podman rootless container engine
- Portainer CE management UI as Docker container

## Test plan
- [ ] `/ninja-rebuild` — cache rebuilds without errors
- [ ] `shellcheck` all 3 scripts

🤖 Generated with [Claude Code](https://claude.com/claude-code)