### PR TITLE
feat: add icon legend to menu banner

### DIFF
--- a/.app/menu.py
+++ b/.app/menu.py
@@ -1773,7 +1773,8 @@ def gum_menu(directory: Path, breadcrumb: List[str] = None) -> None:
                     "--margin", margin_str,
                     "--width", str(layout['content_width']),
                     f"📍 {path_display}",
-                    "Type number to select, b=back, x=exit"
+                    "Type number to select, b=back, x=exit",
+                    "✅ Installed  ⬜ Not installed  🔐 Requires root"
                 ])
 
                 # Pad filter choices for visual centering


### PR DESCRIPTION
## Summary
- Adds status icon legend to the gum menu banner so users know what each symbol means
- Shows: ✅ Installed  ⬜ Not installed  🔐 Requires root

## Test plan
- [ ] Run `ninjamenu`, confirm legend appears in the banner box below nav instructions

🤖 Generated with [Claude Code](https://claude.com/claude-code)