### PR TITLE
fix: add wait_for_apt to clear stuck apt/dpkg locks

### DIFF
--- a/.lib/platform.sh
+++ b/.lib/platform.sh
@@ -112,10 +112,49 @@ _pkg_map_macos() {
 # PACKAGE MANAGEMENT
 #######################################
 
+# wait_for_apt: wait for any running apt/dpkg processes to finish
+# Kills stopped (Ctrl+Z) apt/dpkg processes, then waits up to 60s for
+# active ones to complete before proceeding.
+# Usage: wait_for_apt   (call before any apt-get/dpkg operation)
+wait_for_apt() {
+    [[ "$NT_OS" != "linux" ]] && return 0
+
+    # Kill stopped (T state) apt/dpkg processes — these are orphans from Ctrl+Z
+    local stopped_pids
+    stopped_pids=$(ps -eo pid,stat,comm | awk '$2 ~ /T/ && ($3 == "apt-get" || $3 == "apt" || $3 == "dpkg") {print $1}')
+    if [[ -n "$stopped_pids" ]]; then
+        log_warn "Killing stopped apt/dpkg processes: $stopped_pids"
+        # shellcheck disable=SC2086
+        kill -9 $stopped_pids 2>/dev/null || true
+        sleep 1
+    fi
+
+    # Wait for any active apt/dpkg processes to finish
+    local waited=0
+    while fuser /var/lib/dpkg/lock-frontend &>/dev/null 2>&1; do
+        if [[ $waited -eq 0 ]]; then
+            log_info "Waiting for another apt/dpkg process to finish..."
+        fi
+        sleep 2
+        waited=$((waited + 2))
+        if [[ $waited -ge 60 ]]; then
+            log_error "Timed out waiting for apt/dpkg lock after 60s"
+            log_info "Check with: ps aux | grep -E 'apt|dpkg'"
+            exit 1
+        fi
+    done
+
+    # Clean up stale lock files if no process holds them
+    if [[ -f /var/lib/dpkg/lock-frontend ]] && ! fuser /var/lib/dpkg/lock-frontend &>/dev/null 2>&1; then
+        rm -f /var/lib/dpkg/lock-frontend /var/lib/dpkg/lock /var/cache/apt/archives/lock 2>/dev/null || true
+        dpkg --configure -a 2>/dev/null || true
+    fi
+}
+
 # pkg_update: refresh package index
 pkg_update() {
     case "$NT_OS" in
-        linux)  apt-get update -qq ;;
+        linux)  wait_for_apt; apt-get update -qq ;;
         macos)  brew update --quiet ;;
     esac
 }

--- a/mainmenu/containers/runtime/docker.sh
+++ b/mainmenu/containers/runtime/docker.sh
@@ -20,6 +20,9 @@ install() {
 
     require_root
 
+    # Step 0: Clear any stuck apt/dpkg locks
+    wait_for_apt
+
     # Step 1: Remove old/conflicting packages
     log_step "Removing old Docker packages if present..."
     local OLD_PKGS=(docker.io docker-doc docker-compose podman-docker containerd runc)


### PR DESCRIPTION
## Summary

- Add `wait_for_apt()` helper to `.lib/platform.sh` that kills stopped (Ctrl+Z) apt/dpkg processes, waits for active ones (up to 60s), and cleans stale lock files
- Hook it into `pkg_update()` so all scripts get automatic lock cleanup
- Call it explicitly in `docker.sh` before the manual `apt-get remove` loop that runs before `pkg_update`

## Test plan

- [x] `bash -n` passes on both modified files
- [ ] Suspend a Docker install with Ctrl+Z, re-run — should auto-clear and proceed

🤖 Generated with [Claude Code](https://claude.com/claude-code)