### PR TITLE
fix: batch apt calls and add error trap to Docker install

### DIFF
--- a/.lib/platform.sh
+++ b/.lib/platform.sh
@@ -159,39 +159,39 @@ pkg_update() {
     esac
 }
 
-# pkg_install: install one or more packages
+# pkg_install: install one or more packages (single apt call on Linux)
 # Usage: pkg_install htop btop nmap
 #        pkg_install zenmap  # auto-maps to 'brew install --cask zenmap' on macOS
 pkg_install() {
-    local pkg mapped rc
-    for pkg in "$@"; do
-        if [[ "$NT_OS" == "linux" ]]; then
-            apt-get install -y "$pkg"
-        elif [[ "$NT_OS" == "macos" ]]; then
+    if [[ "$NT_OS" == "linux" ]]; then
+        wait_for_apt
+        apt-get install -y "$@"
+    elif [[ "$NT_OS" == "macos" ]]; then
+        local pkg mapped rc
+        for pkg in "$@"; do
             mapped=$(_pkg_map_macos "$pkg") && rc=0 || rc=$?
             if [[ $rc -eq 0 ]]; then
-                # Mapped to a different brew package/cask name
                 # shellcheck disable=SC2086
                 brew install $mapped
             elif [[ $rc -eq 2 ]]; then
                 log_warn "Package '$pkg' is not available on macOS — skipping"
                 continue
             else
-                # No mapping — use original name as-is
                 brew install "$pkg"
             fi
-        fi
-    done
+        done
+    fi
 }
 
-# pkg_remove: remove one or more packages
+# pkg_remove: remove one or more packages (single apt call on Linux)
 # Usage: pkg_remove htop btop
 pkg_remove() {
-    local pkg mapped rc
-    for pkg in "$@"; do
-        if [[ "$NT_OS" == "linux" ]]; then
-            apt-get remove -y "$pkg"
-        elif [[ "$NT_OS" == "macos" ]]; then
+    if [[ "$NT_OS" == "linux" ]]; then
+        wait_for_apt
+        apt-get remove -y "$@"
+    elif [[ "$NT_OS" == "macos" ]]; then
+        local pkg mapped rc
+        for pkg in "$@"; do
             mapped=$(_pkg_map_macos "$pkg") && rc=0 || rc=$?
             if [[ $rc -eq 0 ]]; then
                 # shellcheck disable=SC2086
@@ -201,8 +201,8 @@ pkg_remove() {
             else
                 brew uninstall "$pkg" 2>/dev/null || true
             fi
-        fi
-    done
+        done
+    fi
 }
 
 #######################################

--- a/mainmenu/containers/runtime/docker.sh
+++ b/mainmenu/containers/runtime/docker.sh
@@ -11,6 +11,9 @@ mkdir -p "$LOG_DIR"
 LOG_FILE="$LOG_DIR/${SCRIPT_NAME}_$(date +%Y%m%d_%H%M%S).log"
 exec > >(tee -a "$LOG_FILE") 2>&1
 
+# Trap errors so failures are visible instead of silent exit
+trap 'log_error "Docker install failed at line $LINENO (exit code $?). Check log: $LOG_FILE"; exit 1' ERR
+
 DATA_ROOT="/opt/app/docker"
 
 install() {
@@ -35,19 +38,30 @@ install() {
     # Step 3: Add Docker GPG key
     log_step "Adding Docker's official GPG key..."
     install -m 0755 -d /etc/apt/keyrings
-    if [[ -f /etc/apt/keyrings/docker.gpg ]]; then
-        rm -f /etc/apt/keyrings/docker.gpg
+    rm -f /etc/apt/keyrings/docker.gpg
+
+    # Resolve distro for Docker repo (Kali uses Debian's repo)
+    local docker_distro docker_codename
+    # shellcheck source=/dev/null
+    . /etc/os-release
+    docker_distro="$ID"
+    docker_codename="${VERSION_CODENAME:-}"
+    if [[ "$docker_distro" == "kali" ]]; then
+        docker_distro="debian"
+        docker_codename="bookworm"
     fi
-    curl -fsSL https://download.docker.com/linux/$(. /etc/os-release && echo "$ID")/gpg | \
-        gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+
+    curl -fsSL "https://download.docker.com/linux/${docker_distro}/gpg" \
+        | gpg --dearmor --batch --yes -o /etc/apt/keyrings/docker.gpg
     chmod a+r /etc/apt/keyrings/docker.gpg
+    log_info "GPG key installed"
 
     # Step 4: Add Docker apt repository
     log_step "Adding Docker apt repository..."
     echo \
         "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] \
-        https://download.docker.com/linux/$(. /etc/os-release && echo "$ID") \
-        $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | \
+        https://download.docker.com/linux/${docker_distro} \
+        ${docker_codename} stable" | \
         tee /etc/apt/sources.list.d/docker.list > /dev/null
     apt-get update
 


### PR DESCRIPTION
## Summary

- **Batch apt calls**: `pkg_install` and `pkg_remove` now pass all packages in a single `apt-get` call on Linux (macOS still loops for per-package name mapping). Eliminates the repeated "Reading package lists / Building dependency tree" output per package.
- **GPG step hardened**: Uses `--batch --yes` flags so gpg doesn't hang or fail on existing files. Resolves distro/codename once into variables (with Kali→Debian fallback) instead of inline subshells.
- **ERR trap**: `trap ... ERR` reports the failing line number, exit code, and log file path — no more silent deaths.

## Test plan

- [x] `bash -n` syntax check passes on both files
- [ ] Run Docker CE install — single "Reading package lists" block for prerequisites
- [ ] GPG step shows "[INFO] GPG key installed" confirmation
- [ ] If any step fails, error message shows line number and log path

🤖 Generated with [Claude Code](https://claude.com/claude-code)