### PR TITLE
fix: break out of action menu on script failure

### DIFF
--- a/.app/menu.py
+++ b/.app/menu.py
@@ -1938,19 +1938,27 @@ def gum_script_action(script_info: ScriptInfo) -> None:
                 return
 
             if selection.startswith("r.") or selection.startswith("i."):
-                run_script(script_info, "install")
+                rc = run_script(script_info, "install")
                 if script_info.script_type not in ("config", "tool"):
                     updated = _reparse_script_info(script_info)
                     if updated:
                         script_info.installed = updated.installed
+                if rc != 0:
+                    print(f"\n⚠ Script failed (exit code {rc}). Returning to menu.")
                 input("\nPress Enter to continue...")
+                if rc != 0:
+                    return
 
             elif selection.startswith("u."):
-                run_script(script_info, "uninstall")
+                rc = run_script(script_info, "uninstall")
                 updated = _reparse_script_info(script_info)
                 if updated:
                     script_info.installed = updated.installed
+                if rc != 0:
+                    print(f"\n⚠ Script failed (exit code {rc}). Returning to menu.")
                 input("\nPress Enter to continue...")
+                if rc != 0:
+                    return
 
             elif selection.startswith("l."):
                 view_log(script_info.path.stem)
@@ -2136,22 +2144,34 @@ def whiptail_script_action(script_info: ScriptInfo) -> None:
                 return
 
             if selection == "run":
-                run_script(script_info, "install")  # Config scripts use install action
+                rc = run_script(script_info, "install")  # Config scripts use install action
+                if rc != 0:
+                    print(f"\n⚠ Script failed (exit code {rc}). Returning to menu.")
                 input("\nPress Enter to continue...")
+                if rc != 0:
+                    return
 
             elif selection == "install":
-                run_script(script_info, "install")
+                rc = run_script(script_info, "install")
                 updated = _reparse_script_info(script_info)
                 if updated:
                     script_info.installed = updated.installed
+                if rc != 0:
+                    print(f"\n⚠ Script failed (exit code {rc}). Returning to menu.")
                 input("\nPress Enter to continue...")
+                if rc != 0:
+                    return
 
             elif selection == "uninstall":
-                run_script(script_info, "uninstall")
+                rc = run_script(script_info, "uninstall")
                 updated = _reparse_script_info(script_info)
                 if updated:
                     script_info.installed = updated.installed
+                if rc != 0:
+                    print(f"\n⚠ Script failed (exit code {rc}). Returning to menu.")
                 input("\nPress Enter to continue...")
+                if rc != 0:
+                    return
 
             elif selection == "log":
                 view_log(script_info.path.stem)


### PR DESCRIPTION
## Summary

- Check `run_script()` return code in both gum and whiptail action menu loops
- On non-zero exit: show failure message with exit code, then return to parent menu
- Prevents infinite loop of Install → fail → Install → fail

## Test plan

- [x] `python3 -c "import py_compile; ..."` passes
- [ ] Script failure shows "Script failed (exit code N)" and returns to parent menu
- [ ] Successful install still loops back to action menu as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)