### PR TITLE
fix: prevent Docker CE install loop caused by apt/dpkg lock contention

### DIFF
--- a/.lib/platform.sh
+++ b/.lib/platform.sh
@@ -113,7 +113,7 @@ _pkg_map_macos() {
 #######################################
 
 # wait_for_apt: wait for any running apt/dpkg processes to finish
-# Kills stopped (Ctrl+Z) apt/dpkg processes, then waits up to 60s for
+# Kills stopped (Ctrl+Z) apt/dpkg processes, then waits up to 120s for
 # active ones to complete before proceeding.
 # Usage: wait_for_apt   (call before any apt-get/dpkg operation)
 wait_for_apt() {
@@ -137,8 +137,11 @@ wait_for_apt() {
         fi
         sleep 2
         waited=$((waited + 2))
-        if [[ $waited -ge 60 ]]; then
-            log_error "Timed out waiting for apt/dpkg lock after 60s"
+        if [[ $((waited % 10)) -eq 0 ]]; then
+            log_info "Still waiting for apt/dpkg lock... (${waited}s elapsed)"
+        fi
+        if [[ $waited -ge 120 ]]; then
+            log_error "Timed out waiting for apt/dpkg lock after 120s"
             log_info "Check with: ps aux | grep -E 'apt|dpkg'"
             exit 1
         fi

--- a/mainmenu/containers/runtime/docker.sh
+++ b/mainmenu/containers/runtime/docker.sh
@@ -33,11 +33,20 @@ install() {
     log_info "Log file: $LOG_FILE"
     echo ""
 
+    export DEBIAN_FRONTEND=noninteractive
+    export APT_LISTCHANGES_FRONTEND=none
+
     require_root
     _resolve_docker_distro
 
-    # Step 0: Clear any stuck apt/dpkg locks
-    wait_for_apt
+    # Restore unattended-upgrades on exit (even on failure)
+    trap 'systemctl start unattended-upgrades 2>/dev/null || true' EXIT
+
+    # Step 0: Stop background apt services to prevent dpkg lock conflicts
+    log_step "Stopping background apt services to prevent lock conflicts..."
+    systemctl stop unattended-upgrades apt-daily apt-daily-upgrade 2>/dev/null || true
+    systemctl kill --kill-who=all unattended-upgrades 2>/dev/null || true
+    sleep 1
 
     # Step 1: Remove old/conflicting packages
     log_step "Removing old Docker packages if present..."
@@ -68,11 +77,11 @@ install() {
     echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/${DOCKER_DISTRO} ${DOCKER_CODENAME} stable" \
         | tee /etc/apt/sources.list.d/docker.list > /dev/null
     log_info "Repo written to /etc/apt/sources.list.d/docker.list"
-    apt-get update
+    pkg_update
 
     # Step 5: Install Docker CE and plugins
     log_step "Installing Docker CE, CLI, containerd, Buildx, and Compose..."
-    apt-get install -y \
+    pkg_install \
         docker-ce \
         docker-ce-cli \
         containerd.io \


### PR DESCRIPTION
## Summary

- **`mainmenu/containers/runtime/docker.sh`**: stop `unattended-upgrades`/`apt-daily` services before any apt activity so the dpkg lock is never contested; set `DEBIAN_FRONTEND=noninteractive` to prevent interactive prompts; remove the redundant direct `wait_for_apt()` call (already called inside `pkg_update`/`pkg_install`); replace raw `apt-get update` and `apt-get install` in steps 4–5 with `pkg_update`/`pkg_install` for consistent lock protection; add `EXIT` trap to restart `unattended-upgrades` whether install succeeds or fails
- **`.lib/platform.sh`**: extend `wait_for_apt` timeout from 60 s → 120 s; add periodic "still waiting" log every 10 s so the user can see progress instead of a silent hang

## Root cause

`unattended-upgrades` on a typical Kali system holds the dpkg lock for minutes at a time. The old `wait_for_apt()` timed out after 60 s and exited with code 1. Every retry hit the same timeout — giving the appearance of a constant install loop.

## Test plan

- [ ] `sudo bash mainmenu/containers/runtime/docker.sh install` — should NOT hang at the start; should complete with `docker --version` and `docker compose version`
- [ ] `docker run hello-world` works after install
- [ ] Penpot path (`Containers → Services → Penpot → Docker CE`) also works (it delegates to the same fixed script)
- [ ] On a system where `unattended-upgrades` is running: confirm "Stopping background apt services" step completes immediately and `unattended-upgrades` is restarted after install

🤖 Generated with [Claude Code](https://claude.com/claude-code)