### PR TITLE
feat: add browser installers and GitHub CLI to menu installer

### DIFF
--- a/.docs/technical_manuals/browsers.md
+++ b/.docs/technical_manuals/browsers.md
@@ -1,0 +1,107 @@
+# Browsers - Technical Manual
+
+## Architecture
+
+Browser scripts are organized under a single submenu:
+- `desktop/` - Full-featured desktop web browsers
+
+All scripts are Tier 2 (sibling `.meta.yaml`). Chrome, Opera, and Brave follow the GPG key + apt repo pattern (similar to `databases/rabbitmq.sh`). Firefox uses the default distribution repositories.
+
+## Scripts Reference
+
+### desktop/google-chrome.sh
+
+**Purpose:** Install Google Chrome (stable channel)
+
+**Installation method:** GPG key + apt repository
+```bash
+# GPG key
+curl -fsSL https://dl.google.com/linux/linux_signing_key.pub | gpg --dearmor -o /usr/share/keyrings/google-chrome.gpg
+
+# Repo (amd64 only)
+deb [arch=amd64 signed-by=/usr/share/keyrings/google-chrome.gpg] https://dl.google.com/linux/chrome/deb/ stable main
+```
+
+**Architecture guard:** Checks `dpkg --print-architecture` for amd64; exits with error on other architectures.
+
+**Check:** `google-chrome --version`
+
+**File locations:**
+- GPG key: `/usr/share/keyrings/google-chrome.gpg`
+- Repo: `/etc/apt/sources.list.d/google-chrome.list`
+
+### desktop/opera.sh
+
+**Purpose:** Install Opera Browser (stable channel)
+
+**Installation method:** GPG key + apt repository
+```bash
+# GPG key
+curl -fsSL https://deb.opera.com/archive.key | gpg --dearmor -o /usr/share/keyrings/opera-browser.gpg
+
+# Repo
+deb [signed-by=/usr/share/keyrings/opera-browser.gpg] https://deb.opera.com/opera-stable/ stable non-free
+```
+
+**Check:** `opera --version`
+
+**File locations:**
+- GPG key: `/usr/share/keyrings/opera-browser.gpg`
+- Repo: `/etc/apt/sources.list.d/opera-stable.list`
+
+### desktop/brave.sh
+
+**Purpose:** Install Brave Browser
+
+**Installation method:** Binary GPG key + apt repository
+```bash
+# GPG key (direct binary download, no dearmor needed)
+curl -fsSLo /usr/share/keyrings/brave-browser-archive-keyring.gpg \
+    https://brave-browser-apt-release.s3.brave.com/brave-browser-archive-keyring.gpg
+
+# Repo
+deb [signed-by=/usr/share/keyrings/brave-browser-archive-keyring.gpg] https://brave-browser-apt-release.s3.brave.com/ stable main
+```
+
+**Check:** `brave-browser --version`
+
+**File locations:**
+- GPG key: `/usr/share/keyrings/brave-browser-archive-keyring.gpg`
+- Repo: `/etc/apt/sources.list.d/brave-browser-release.list`
+
+### desktop/firefox.sh
+
+**Purpose:** Install Firefox ESR
+
+**Installation method:** Default distribution repositories (no GPG key or repo setup needed)
+```bash
+pkg_update
+pkg_install firefox-esr
+```
+
+**Check:** `firefox-esr --version`
+
+## Dependencies
+
+- `curl`, `gnupg`, `apt-transport-https` — for Chrome, Opera, Brave (repo setup)
+- No extra dependencies for Firefox ESR
+
+## Security Notes
+
+- All third-party repositories use GPG-signed packages via `/usr/share/keyrings/` (modern apt keyring approach)
+- No keys are added to the global trusted keyring (`/etc/apt/trusted.gpg`)
+- Uninstall scripts clean up both the repo file and GPG key
+
+## Development
+
+### Adding a New Browser
+
+1. Copy `google-chrome.sh` and `google-chrome.meta.yaml` as templates
+2. Update GPG key URL, repo URL, and package name
+3. Set appropriate `check_command` in `.meta.yaml`
+4. Update `order` field for menu positioning
+5. Update README.md, user manual, and technical manual
+
+## See Also
+
+- [User Guide](../user_manuals/browsers.md)

--- a/.docs/user_manuals/browsers.md
+++ b/.docs/user_manuals/browsers.md
@@ -1,0 +1,87 @@
+# Browsers - User Guide
+
+## Overview
+
+The Browsers menu provides installers for popular desktop web browsers on Debian-based systems. Each script handles GPG key setup, repository configuration, and package installation.
+
+## Available Browsers
+
+### Google Chrome
+
+Google's fast, secure web browser. Available on amd64 architecture only.
+
+**Installation:**
+1. Run `ninjamenu` → Browsers → Desktop Browsers → Google Chrome
+2. Launch from applications menu or run `google-chrome`
+
+**Usage:**
+```bash
+google-chrome              # Launch browser
+google-chrome --incognito  # Launch in incognito mode
+```
+
+### Opera
+
+Feature-rich browser with built-in VPN, ad blocker, and sidebar messenger integrations.
+
+**Installation:**
+1. Run `ninjamenu` → Browsers → Desktop Browsers → Opera
+2. Launch from applications menu or run `opera`
+
+**Usage:**
+```bash
+opera            # Launch browser
+opera --private  # Launch in private mode
+```
+
+### Brave
+
+Privacy-focused browser built on Chromium with built-in ad and tracker blocking.
+
+**Installation:**
+1. Run `ninjamenu` → Browsers → Desktop Browsers → Brave
+2. Launch from applications menu or run `brave-browser`
+
+**Usage:**
+```bash
+brave-browser              # Launch browser
+brave-browser --incognito  # Launch in private mode
+```
+
+### Firefox ESR
+
+Mozilla's open-source browser, Extended Support Release for long-term stability.
+
+**Installation:**
+1. Run `ninjamenu` → Browsers → Desktop Browsers → Firefox ESR
+2. Launch from applications menu or run `firefox-esr`
+
+**Usage:**
+```bash
+firefox-esr              # Launch browser
+firefox-esr --private    # Launch in private mode
+```
+
+## Prerequisites
+
+- Root/sudo access
+- Debian-based system (Kali, Debian, Ubuntu)
+- Internet connection for downloading packages and GPG keys
+
+## Troubleshooting
+
+### Browser won't launch from terminal
+
+**Solution:** Try launching with `--no-sandbox` flag (not recommended for regular use) or check if a display server is running.
+
+### GPG key errors during install
+
+**Solution:** The scripts handle GPG key import automatically. If you see errors, check your internet connection and retry.
+
+### Google Chrome says "unsupported architecture"
+
+**Solution:** Chrome only supports amd64 (x86_64). On ARM systems, use Firefox ESR or Brave (if available for your architecture).
+
+## See Also
+
+- [Technical Manual](../technical_manuals/browsers.md)

--- a/install_menu.sh
+++ b/install_menu.sh
@@ -16,7 +16,7 @@
 
 #######################################
 # MENU SYSTEM INSTALLER
-# Installs: Python3, pip, textual, gum, whiptail, dialog
+# Installs: Python3, pip, textual, gum, gh CLI, whiptail, dialog
 #######################################
 
 set -euo pipefail
@@ -162,7 +162,60 @@ else
 fi
 
 #######################################
-# STEP 3: Python virtual environment
+# STEP 3: Install GitHub CLI (gh)
+#######################################
+log_step "Installing GitHub CLI (gh)..."
+
+if command -v gh &>/dev/null; then
+    log_info "GitHub CLI already installed: $(gh --version | head -1)"
+else
+    if [[ "$OS_TYPE" == "linux" ]]; then
+        mkdir -p /etc/apt/keyrings
+        curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+            -o /etc/apt/keyrings/githubcli-archive-keyring.gpg
+        chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg
+        echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+            | tee /etc/apt/sources.list.d/github-cli.list > /dev/null
+        apt-get update -qq
+        apt-get install -y gh
+    elif [[ "$OS_TYPE" == "macos" ]]; then
+        brew install gh
+    fi
+    log_success "GitHub CLI installed"
+fi
+
+# Authenticate gh if not already logged in
+if command -v gh &>/dev/null; then
+    if gh auth status &>/dev/null 2>&1; then
+        log_info "GitHub CLI already authenticated"
+    else
+        echo ""
+        read -rp "Would you like to authenticate GitHub CLI (gh) now? (y/n) " gh_answer
+        if [[ "$gh_answer" =~ ^[Yy]$ ]]; then
+            log_info "Starting GitHub CLI authentication..."
+            log_info "This enables PR workflows (create, merge, review)"
+            # Run as the actual user, not root — gh auth stores tokens per-user
+            if [[ "$OS_TYPE" == "linux" && $EUID -eq 0 && -n "${SUDO_USER:-}" ]]; then
+                sudo -u "$SUDO_USER" gh auth login
+            else
+                gh auth login
+            fi
+            if gh auth status &>/dev/null 2>&1; then
+                log_success "GitHub CLI authenticated"
+            else
+                log_warn "GitHub CLI authentication skipped or failed"
+                log_info "You can authenticate later with: gh auth login"
+            fi
+        else
+            log_info "Skipping GitHub CLI authentication"
+            log_info "You can authenticate later with: gh auth login"
+        fi
+    fi
+fi
+
+#######################################
+# STEP 4: Python virtual environment
+# (was Step 3 before gh CLI was added)
 #######################################
 log_step "Setting up Python virtual environment..."
 
@@ -193,7 +246,7 @@ log_success "Python packages installed"
 deactivate
 
 #######################################
-# STEP 4: Create launcher script
+# STEP 5: Create launcher script
 #######################################
 log_step "Creating launcher script..."
 
@@ -213,7 +266,7 @@ chmod +x "$MENU_ROOT/.app/menu"
 log_success "Launcher script created"
 
 #######################################
-# STEP 4b: Build initial menu cache
+# STEP 5b: Build initial menu cache
 #######################################
 log_step "Building initial menu cache..."
 
@@ -227,7 +280,7 @@ deactivate
 log_success "Menu cache built"
 
 #######################################
-# STEP 5: Set permissions
+# STEP 6: Set permissions
 #######################################
 log_step "Setting permissions..."
 
@@ -253,7 +306,7 @@ chown -R "$ACTUAL_USER:$ACTUAL_GROUP" "$MENU_ROOT" 2>/dev/null || true
 log_success "Permissions set"
 
 #######################################
-# STEP 6: Create system-wide ninjamenu command
+# STEP 7: Create system-wide ninjamenu command
 #######################################
 log_step "Creating ninjamenu command in $BIN_DIR..."
 
@@ -288,7 +341,7 @@ chmod +x "$BIN_DIR/ninjamenu"
 log_success "ninjamenu command installed at $BIN_DIR/ninjamenu"
 
 #######################################
-# STEP 7: Update installed status
+# STEP 8: Update installed status
 #######################################
 if [[ "$OS_TYPE" == "macos" ]]; then
     sed -i '' 's/^# installed: .*/# installed: true/' "${BASH_SOURCE[0]}"
@@ -309,6 +362,7 @@ echo -e "${GREEN}Installed components:${NC}"
 echo "  - Python 3 with venv"
 echo "  - Textual TUI framework"
 echo "  - Gum (Charm.sh) for beautiful prompts"
+echo "  - GitHub CLI (gh) for PR workflows"
 echo "  - whiptail/dialog fallback"
 echo "  - PyYAML, Rich, Typer"
 echo "  - SQLite menu cache"

--- a/mainmenu/browsers/README.md
+++ b/mainmenu/browsers/README.md
@@ -1,0 +1,42 @@
+# Browsers
+
+Web browser installers for desktop environments.
+
+## Scripts
+
+| Script | Description | Type |
+|--------|-------------|------|
+| Google Chrome | Google's fast, secure web browser | install |
+| Opera | Feature-rich browser with built-in VPN and ad blocker | install |
+| Brave | Privacy-focused browser with built-in ad and tracker blocking | install |
+| Firefox ESR | Mozilla's open-source browser (Extended Support Release) | install |
+
+## Quick Start
+
+```bash
+ninjamenu
+# Navigate to: Browsers -> Desktop Browsers -> pick a browser
+```
+
+## Included Browsers
+
+### Desktop Browsers
+
+- **Google Chrome** - Full-featured browser from Google (amd64 only)
+- **Opera** - Feature-rich browser with built-in VPN
+- **Brave** - Privacy-first browser based on Chromium
+- **Firefox ESR** - Mozilla's long-term support release
+
+## Documentation
+
+- [User Guide](../../.docs/user_manuals/browsers.md) - Usage instructions
+- [Technical Manual](../../.docs/technical_manuals/browsers.md) - Developer docs
+
+## Requirements
+
+- Root access for installation
+- All browsers install via apt with GPG-signed repositories (except Firefox which uses default repos)
+
+## Tags
+
+`browser` `web` `chrome` `opera` `brave` `firefox`

--- a/mainmenu/browsers/category.yaml
+++ b/mainmenu/browsers/category.yaml
@@ -1,0 +1,2 @@
+name: "Browsers"
+description: "Web browser installers for desktop environments"

--- a/mainmenu/browsers/desktop/brave.meta.yaml
+++ b/mainmenu/browsers/desktop/brave.meta.yaml
@@ -1,0 +1,21 @@
+name: "Brave"
+description: "Privacy-focused browser with built-in ad and tracker blocking"
+version: "1.0.0"
+author: "Ninja Toolbox"
+type: install
+root: true
+order: 30
+hidden: false
+installed: false
+check_command: "brave-browser --version"
+dependencies:
+  - curl
+  - gnupg
+tags:
+  - browser
+  - web
+  - privacy
+supported_os:
+  - kali
+  - debian
+  - ubuntu

--- a/mainmenu/browsers/desktop/brave.sh
+++ b/mainmenu/browsers/desktop/brave.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+# Metadata lives in the companion .meta.yaml file (NOT inline).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT_NAME="$(basename "${BASH_SOURCE[0]}" .sh)"
+MENU_ROOT="${MENU_ROOT:-$(cd "$SCRIPT_DIR" && while [[ ! -f "install_menu.sh" ]] && [[ "$PWD" != "/" ]]; do cd ..; done; pwd)}"
+
+source "$MENU_ROOT/.lib/platform.sh"
+
+LOG_DIR="$MENU_ROOT/.docs/logs"
+mkdir -p "$LOG_DIR"
+LOG_FILE="$LOG_DIR/${SCRIPT_NAME}_$(date +%Y%m%d_%H%M%S).log"
+exec > >(tee -a "$LOG_FILE") 2>&1
+
+KEYRING="/usr/share/keyrings/brave-browser-archive-keyring.gpg"
+SOURCES_LIST="/etc/apt/sources.list.d/brave-browser-release.list"
+
+install() {
+    log_info "Installing Brave Browser"
+    log_info "Log file: $LOG_FILE"
+    echo ""
+
+    require_root
+
+    log_step "1. Adding Brave repository..."
+    pkg_install curl gnupg apt-transport-https
+
+    curl -fsSLo "$KEYRING" \
+        https://brave-browser-apt-release.s3.brave.com/brave-browser-archive-keyring.gpg
+
+    cat > "$SOURCES_LIST" <<EOF
+deb [signed-by=${KEYRING}] https://brave-browser-apt-release.s3.brave.com/ stable main
+EOF
+
+    log_step "2. Installing brave-browser..."
+    pkg_update
+    pkg_install brave-browser
+
+    log_step "3. Verifying installation..."
+    brave-browser --version
+
+    echo ""
+    log_success "Brave Browser installed"
+    mark_installed true
+}
+
+uninstall() {
+    log_info "Uninstalling Brave Browser"
+    require_root
+
+    pkg_remove brave-browser
+    rm -f "$SOURCES_LIST"
+    rm -f "$KEYRING"
+    apt-get autoremove -y 2>/dev/null || true
+
+    log_success "Brave Browser uninstalled"
+    mark_installed false
+}
+
+case "${1:-install}" in
+    install) install ;;
+    uninstall) uninstall ;;
+    *) echo "Usage: $0 {install|uninstall}"; exit 1 ;;
+esac

--- a/mainmenu/browsers/desktop/category.yaml
+++ b/mainmenu/browsers/desktop/category.yaml
@@ -1,0 +1,2 @@
+name: "Desktop Browsers"
+description: "Full-featured desktop web browsers"

--- a/mainmenu/browsers/desktop/firefox.meta.yaml
+++ b/mainmenu/browsers/desktop/firefox.meta.yaml
@@ -1,0 +1,19 @@
+name: "Firefox ESR"
+description: "Mozilla's open-source browser (Extended Support Release)"
+version: "1.0.0"
+author: "Ninja Toolbox"
+type: install
+root: true
+order: 40
+hidden: false
+installed: false
+check_command: "firefox-esr --version"
+tags:
+  - browser
+  - web
+  - mozilla
+  - open-source
+supported_os:
+  - kali
+  - debian
+  - ubuntu

--- a/mainmenu/browsers/desktop/firefox.sh
+++ b/mainmenu/browsers/desktop/firefox.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+# Metadata lives in the companion .meta.yaml file (NOT inline).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT_NAME="$(basename "${BASH_SOURCE[0]}" .sh)"
+MENU_ROOT="${MENU_ROOT:-$(cd "$SCRIPT_DIR" && while [[ ! -f "install_menu.sh" ]] && [[ "$PWD" != "/" ]]; do cd ..; done; pwd)}"
+
+source "$MENU_ROOT/.lib/platform.sh"
+
+LOG_DIR="$MENU_ROOT/.docs/logs"
+mkdir -p "$LOG_DIR"
+LOG_FILE="$LOG_DIR/${SCRIPT_NAME}_$(date +%Y%m%d_%H%M%S).log"
+exec > >(tee -a "$LOG_FILE") 2>&1
+
+install() {
+    log_info "Installing Firefox ESR"
+    log_info "Log file: $LOG_FILE"
+    echo ""
+
+    require_root
+
+    log_step "1. Installing firefox-esr from default repositories..."
+    pkg_update
+    pkg_install firefox-esr
+
+    log_step "2. Verifying installation..."
+    firefox-esr --version
+
+    echo ""
+    log_success "Firefox ESR installed"
+    mark_installed true
+}
+
+uninstall() {
+    log_info "Uninstalling Firefox ESR"
+    require_root
+
+    pkg_remove firefox-esr
+    apt-get autoremove -y 2>/dev/null || true
+
+    log_success "Firefox ESR uninstalled"
+    mark_installed false
+}
+
+case "${1:-install}" in
+    install) install ;;
+    uninstall) uninstall ;;
+    *) echo "Usage: $0 {install|uninstall}"; exit 1 ;;
+esac

--- a/mainmenu/browsers/desktop/google-chrome.meta.yaml
+++ b/mainmenu/browsers/desktop/google-chrome.meta.yaml
@@ -1,0 +1,21 @@
+name: "Google Chrome"
+description: "Google's fast, secure web browser"
+version: "1.0.0"
+author: "Ninja Toolbox"
+type: install
+root: true
+order: 10
+hidden: false
+installed: false
+check_command: "google-chrome --version"
+dependencies:
+  - curl
+  - gnupg
+tags:
+  - browser
+  - web
+  - google
+supported_os:
+  - kali
+  - debian
+  - ubuntu

--- a/mainmenu/browsers/desktop/google-chrome.sh
+++ b/mainmenu/browsers/desktop/google-chrome.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+# Metadata lives in the companion .meta.yaml file (NOT inline).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT_NAME="$(basename "${BASH_SOURCE[0]}" .sh)"
+MENU_ROOT="${MENU_ROOT:-$(cd "$SCRIPT_DIR" && while [[ ! -f "install_menu.sh" ]] && [[ "$PWD" != "/" ]]; do cd ..; done; pwd)}"
+
+source "$MENU_ROOT/.lib/platform.sh"
+
+LOG_DIR="$MENU_ROOT/.docs/logs"
+mkdir -p "$LOG_DIR"
+LOG_FILE="$LOG_DIR/${SCRIPT_NAME}_$(date +%Y%m%d_%H%M%S).log"
+exec > >(tee -a "$LOG_FILE") 2>&1
+
+KEYRING="/usr/share/keyrings/google-chrome.gpg"
+SOURCES_LIST="/etc/apt/sources.list.d/google-chrome.list"
+
+install() {
+    log_info "Installing Google Chrome"
+    log_info "Log file: $LOG_FILE"
+    echo ""
+
+    require_root
+
+    log_step "1. Checking architecture..."
+    ARCH="$(dpkg --print-architecture)"
+    if [[ "$ARCH" != "amd64" ]]; then
+        log_error "Google Chrome only supports amd64. Detected: $ARCH"
+        exit 1
+    fi
+
+    log_step "2. Adding Google Chrome repository..."
+    pkg_install curl gnupg apt-transport-https
+
+    curl -fsSL https://dl.google.com/linux/linux_signing_key.pub | \
+        gpg --dearmor -o "$KEYRING" 2>/dev/null || true
+
+    cat > "$SOURCES_LIST" <<EOF
+deb [arch=amd64 signed-by=${KEYRING}] https://dl.google.com/linux/chrome/deb/ stable main
+EOF
+
+    log_step "3. Installing google-chrome-stable..."
+    pkg_update
+    pkg_install google-chrome-stable
+
+    log_step "4. Verifying installation..."
+    google-chrome --version
+
+    echo ""
+    log_success "Google Chrome installed"
+    mark_installed true
+}
+
+uninstall() {
+    log_info "Uninstalling Google Chrome"
+    require_root
+
+    pkg_remove google-chrome-stable
+    rm -f "$SOURCES_LIST"
+    rm -f "$KEYRING"
+    apt-get autoremove -y 2>/dev/null || true
+
+    log_success "Google Chrome uninstalled"
+    mark_installed false
+}
+
+case "${1:-install}" in
+    install) install ;;
+    uninstall) uninstall ;;
+    *) echo "Usage: $0 {install|uninstall}"; exit 1 ;;
+esac

--- a/mainmenu/browsers/desktop/opera.meta.yaml
+++ b/mainmenu/browsers/desktop/opera.meta.yaml
@@ -1,0 +1,21 @@
+name: "Opera"
+description: "Feature-rich browser with built-in VPN and ad blocker"
+version: "1.0.0"
+author: "Ninja Toolbox"
+type: install
+root: true
+order: 20
+hidden: false
+installed: false
+check_command: "opera --version"
+dependencies:
+  - curl
+  - gnupg
+tags:
+  - browser
+  - web
+  - opera
+supported_os:
+  - kali
+  - debian
+  - ubuntu

--- a/mainmenu/browsers/desktop/opera.sh
+++ b/mainmenu/browsers/desktop/opera.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+# Metadata lives in the companion .meta.yaml file (NOT inline).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT_NAME="$(basename "${BASH_SOURCE[0]}" .sh)"
+MENU_ROOT="${MENU_ROOT:-$(cd "$SCRIPT_DIR" && while [[ ! -f "install_menu.sh" ]] && [[ "$PWD" != "/" ]]; do cd ..; done; pwd)}"
+
+source "$MENU_ROOT/.lib/platform.sh"
+
+LOG_DIR="$MENU_ROOT/.docs/logs"
+mkdir -p "$LOG_DIR"
+LOG_FILE="$LOG_DIR/${SCRIPT_NAME}_$(date +%Y%m%d_%H%M%S).log"
+exec > >(tee -a "$LOG_FILE") 2>&1
+
+KEYRING="/usr/share/keyrings/opera-browser.gpg"
+SOURCES_LIST="/etc/apt/sources.list.d/opera-stable.list"
+
+install() {
+    log_info "Installing Opera Browser"
+    log_info "Log file: $LOG_FILE"
+    echo ""
+
+    require_root
+
+    log_step "1. Adding Opera repository..."
+    pkg_install curl gnupg apt-transport-https
+
+    curl -fsSL https://deb.opera.com/archive.key | \
+        gpg --dearmor -o "$KEYRING" 2>/dev/null || true
+
+    cat > "$SOURCES_LIST" <<EOF
+deb [signed-by=${KEYRING}] https://deb.opera.com/opera-stable/ stable non-free
+EOF
+
+    log_step "2. Installing opera-stable..."
+    pkg_update
+    pkg_install opera-stable
+
+    log_step "3. Verifying installation..."
+    opera --version
+
+    echo ""
+    log_success "Opera Browser installed"
+    mark_installed true
+}
+
+uninstall() {
+    log_info "Uninstalling Opera Browser"
+    require_root
+
+    pkg_remove opera-stable
+    rm -f "$SOURCES_LIST"
+    rm -f "$KEYRING"
+    apt-get autoremove -y 2>/dev/null || true
+
+    log_success "Opera Browser uninstalled"
+    mark_installed false
+}
+
+case "${1:-install}" in
+    install) install ;;
+    uninstall) uninstall ;;
+    *) echo "Usage: $0 {install|uninstall}"; exit 1 ;;
+esac


### PR DESCRIPTION
## Summary
- Adds new `mainmenu/browsers/` top-level menu section with 4 desktop browser installers (Chrome, Opera, Brave, Firefox ESR)
- Adds GitHub CLI (`gh`) installation + interactive authentication to `install_menu.sh` to enable PR workflows out of the box
- Includes full documentation: folder README, user manual, technical manual

## Test plan
- [ ] `./menu.py --list` shows Browsers section with all 4 scripts
- [ ] `/ninja-rebuild` cache rebuild succeeds
- [ ] Each `.meta.yaml` has correct fields
- [ ] `install_menu.sh` installs `gh` and prompts for auth
- [ ] Do NOT execute browser install scripts

🤖 Generated with [Claude Code](https://claude.com/claude-code)