### PR TITLE
feat: add toolsets category with terminals, dev tools, and theming

### DIFF
--- a/.docs/technical_manuals/toolsets.md
+++ b/.docs/technical_manuals/toolsets.md
@@ -1,0 +1,87 @@
+# Toolsets - Technical Manual
+
+## Architecture
+
+The toolsets category is divided into three subcategories, each in its own subfolder:
+
+```
+mainmenu/toolsets/
+├── terminals/          # GPU-accelerated terminal emulators (Tier 2)
+├── dev-tools/          # CLI developer tools (Tier 2)
+└── theming/            # Catppuccin Mocha theme configs (mixed Tier 1 + Tier 2)
+```
+
+All install scripts are Tier 2 (single `.sh` + `.meta.yaml`) except `catppuccin-kde/` which is Tier 1 (folder with `meta.yaml`, `_common.sh`, `linux.sh`) because KDE theming is Linux-specific and may gain macOS/Windows support later.
+
+## Scripts Reference
+
+### Terminals
+
+| Script | Package | Binary | Check |
+|--------|---------|--------|-------|
+| `kitty.sh` | `kitty` (apt) | `/usr/bin/kitty` | `kitty --version` |
+| `wezterm.sh` | `wezterm` (apt.fury.io/wez/) | `/usr/bin/wezterm` | `wezterm --version` |
+| `alacritty.sh` | `alacritty` (apt) | `/usr/bin/alacritty` | `alacritty --version` |
+
+**WezTerm** uses a third-party APT repository (apt.fury.io). The GPG key is stored at `/usr/share/keyrings/wezterm-fury.gpg` and the source list at `/etc/apt/sources.list.d/wezterm.list`. Both are cleaned up on uninstall.
+
+### Developer Tools
+
+| Script | Package | Binary | Check | Notes |
+|--------|---------|--------|-------|-------|
+| `neovim.sh` | `neovim` | `/usr/bin/nvim` | `nvim --version` | |
+| `tmux.sh` | `tmux` | `/usr/bin/tmux` | `tmux -V` | |
+| `ripgrep.sh` | `ripgrep` | `/usr/bin/rg` | `rg --version` | |
+| `fd.sh` | `fd-find` | `/usr/bin/fdfind` | `fdfind --version` | Symlink to `/usr/local/bin/fd` |
+| `fzf.sh` | `fzf` | `/usr/bin/fzf` | `fzf --version` | |
+| `bat.sh` | `bat` | `/usr/bin/batcat` | `batcat --version` | Symlink to `/usr/local/bin/bat` |
+| `lazygit.sh` | GitHub release | `/usr/local/bin/lazygit` | `lazygit --version` | Downloads latest tar.gz from GitHub API |
+
+**fd and bat binary naming:** On Debian/Ubuntu, `fd-find` installs as `fdfind` and `bat` installs as `batcat` to avoid conflicts with existing packages. The scripts create convenience symlinks at `/usr/local/bin/`.
+
+**lazygit installation:** Downloads the latest release from the GitHub API (`jesseduffield/lazygit`), extracts the `lazygit` binary from the tar.gz, and installs it to `/usr/local/bin/` using the `install` command. No APT repository is needed.
+
+### Theming
+
+| Script | Type | Tier | Targets |
+|--------|------|------|---------|
+| `catppuccin-kde/` | install | 1 | KDE color schemes, Kvantum Qt theme |
+| `catppuccin-terminals.sh` | config | 2 | kitty, WezTerm, Alacritty color configs |
+| `catppuccin-neovim.sh` | config | 2 | Neovim catppuccin plugin (lazy.nvim/packer) |
+| `catppuccin-tmux.sh` | config | 2 | tmux via TPM plugin |
+| `catppuccin-hyprland.sh` | config | 2 | Hyprland borders, Waybar CSS, Wofi CSS |
+
+**Config scripts** (`type: config`) show a "Run" action in the menu rather than Install/Uninstall. They do not track installation state and do not require root.
+
+**No overlap with postsetup-kali:** The existing `catppuccin-themes` in `postsetup-kali/` targets XFCE, GTK, ZSH prompt, and VS Code. These scripts target KDE Plasma, GPU terminals, Neovim, tmux, and Hyprland.
+
+## File Paths Written by Theming Scripts
+
+| Script | Files created |
+|--------|--------------|
+| catppuccin-kde | `~/.local/share/color-schemes/CatppuccinMocha*`, `~/.config/Kvantum/*Mocha*` |
+| catppuccin-terminals | `~/.config/kitty/catppuccin-mocha.conf`, `~/.config/wezterm/colors/catppuccin-mocha.toml`, `~/.config/alacritty/catppuccin-mocha.toml` |
+| catppuccin-neovim | `~/.config/nvim/lua/plugins/catppuccin.lua` |
+| catppuccin-tmux | `~/.tmux/plugins/tpm/` (if missing), appends to `~/.tmux.conf` |
+| catppuccin-hyprland | `~/.config/hypr/catppuccin-mocha.conf`, `~/.config/waybar/catppuccin-mocha.css`, `~/.config/wofi/catppuccin-mocha.css` |
+
+## Development
+
+### Adding a new terminal or dev tool
+
+1. Create `<tool>.sh` + `<tool>.meta.yaml` in the appropriate subfolder
+2. Follow the Tier 2 pattern: `pkg_install` for apt packages, or download from GitHub for binary releases
+3. Set `check_command` and `check_path` for installation detection
+4. Update the folder README.md
+
+### Adding a new theming target
+
+1. Create `catppuccin-<target>.sh` + `catppuccin-<target>.meta.yaml` in `theming/`
+2. Use `type: config` and `root: false`
+3. Write color config files to `~/.config/<target>/`
+4. Only configure if the target tool is installed (`command -v`)
+
+## See Also
+
+- [User Guide](../user_manuals/toolsets.md)
+- [Contributing Guide](../../mainmenu/CONTRIBUTING.md)

--- a/.docs/user_manuals/toolsets.md
+++ b/.docs/user_manuals/toolsets.md
@@ -1,0 +1,151 @@
+# Toolsets - User Guide
+
+## Overview
+
+The Toolsets category provides GPU-accelerated terminal emulators, essential CLI developer tools, and a unified Catppuccin Mocha theming suite. Install the tools first, then apply consistent theming across all of them.
+
+## Terminal Emulators
+
+### kitty
+
+GPU-accelerated terminal with image display and ligature support.
+
+```bash
+kitty                    # Launch kitty
+kitty +kitten icat image.png  # Display image inline
+```
+
+### WezTerm
+
+GPU-accelerated terminal with a built-in multiplexer and Lua configuration.
+
+```bash
+wezterm                  # Launch WezTerm
+wezterm cli split-pane   # Split the current pane
+```
+
+Configuration lives in `~/.config/wezterm/wezterm.lua`.
+
+### Alacritty
+
+Minimal, GPU-accelerated terminal focused on speed. No tabs or splits -- pair with tmux.
+
+```bash
+alacritty                # Launch Alacritty
+```
+
+Configuration lives in `~/.config/alacritty/alacritty.toml`.
+
+## Developer Tools
+
+### Neovim
+
+Hyperextensible text editor built on Vim. Supports Lua plugins and LSP natively.
+
+```bash
+nvim file.py             # Edit a file
+nvim +checkhealth        # Verify installation health
+```
+
+### tmux
+
+Terminal multiplexer for persistent sessions with splits and tabs.
+
+```bash
+tmux                     # Start new session
+tmux new -s dev          # Named session
+tmux attach -t dev       # Reattach
+```
+
+Key bindings (default prefix: `Ctrl-b`):
+- `prefix + %` -- vertical split
+- `prefix + "` -- horizontal split
+- `prefix + d` -- detach
+
+### ripgrep (rg)
+
+Fast recursive search, respects `.gitignore` by default.
+
+```bash
+rg "TODO"                # Search current directory
+rg -t py "def main"      # Search only Python files
+rg -i "error" --glob "*.log"  # Case-insensitive in logs
+```
+
+### fd
+
+Fast file finder, alternative to `find`.
+
+```bash
+fd "\.py$"               # Find Python files
+fd -t d "src"            # Find directories named src
+fd -e json               # Find by extension
+```
+
+### fzf
+
+Interactive fuzzy finder. Pipe anything into it.
+
+```bash
+fzf                      # Browse files interactively
+history | fzf            # Search shell history
+fd | fzf --preview 'bat {}'  # Preview files with bat
+```
+
+### bat
+
+`cat` replacement with syntax highlighting and line numbers.
+
+```bash
+bat script.sh            # View with syntax highlighting
+bat --diff file.txt      # Show git diff
+bat -l yaml config.yml   # Force language
+```
+
+### lazygit
+
+Terminal UI for Git. Navigate commits, branches, and diffs visually.
+
+```bash
+lazygit                  # Launch in current repo
+```
+
+## Catppuccin Theming
+
+The theming scripts apply the Catppuccin Mocha color palette consistently across your desktop and tools. They do not overlap with the XFCE/GTK themes in postsetup-kali -- these target KDE, terminals, Neovim, tmux, and Hyprland.
+
+### Recommended order
+
+1. Install terminals and dev tools first
+2. Run **Catppuccin KDE** (if using KDE Plasma)
+3. Run **Catppuccin Terminals** to theme whichever terminals you installed
+4. Run **Catppuccin Neovim** to add the colorscheme plugin
+5. Run **Catppuccin tmux** to configure TPM with the theme
+6. Run **Catppuccin Hyprland** (if using Hyprland compositor)
+
+### Tips
+
+- Terminal theme scripts only configure terminals that are already installed
+- The Neovim script auto-detects lazy.nvim or packer and writes the correct plugin spec
+- The tmux script installs TPM (tmux plugin manager) if missing; press `prefix + I` to activate
+- Hyprland colors are sourced via `source =` directive -- reload with `hyprctl reload`
+
+## Troubleshooting
+
+### fd and bat have different binary names
+
+On Debian/Ubuntu, `fd` is installed as `fdfind` and `bat` as `batcat` to avoid name conflicts. The install scripts create symlinks at `/usr/local/bin/fd` and `/usr/local/bin/bat` automatically.
+
+### lazygit version
+
+lazygit is installed from the latest GitHub release binary. To update, simply re-run the install script.
+
+### Terminal colors look wrong
+
+Ensure your terminal supports true color (24-bit). Check with:
+
+```bash
+echo -e "\e[38;2;255;100;0mTrueColor test\e[0m"
+```
+
+If the text appears orange, true color is supported.

--- a/mainmenu/toolsets/README.md
+++ b/mainmenu/toolsets/README.md
@@ -1,0 +1,57 @@
+# Toolsets
+
+Developer toolsets including GPU-accelerated terminals, CLI dev tools, and Catppuccin theming.
+
+## Categories
+
+### Terminal Emulators
+
+| Script | Description | Type |
+|--------|-------------|------|
+| kitty | GPU-accelerated terminal emulator with ligature support | install |
+| WezTerm | GPU-accelerated terminal emulator with multiplexer built-in | install |
+| Alacritty | GPU-accelerated terminal emulator focused on simplicity and speed | install |
+
+### Developer Tools
+
+| Script | Description | Type |
+|--------|-------------|------|
+| Neovim | Hyperextensible Vim-based text editor | install |
+| tmux | Terminal multiplexer for managing multiple sessions | install |
+| ripgrep | Blazing fast recursive grep replacement | install |
+| fd | Fast and user-friendly alternative to find | install |
+| fzf | Command-line fuzzy finder for files, history, and more | install |
+| bat | Cat clone with syntax highlighting and Git integration | install |
+| lazygit | Simple terminal UI for Git commands | install |
+
+### Catppuccin Theming
+
+| Script | Description | Type |
+|--------|-------------|------|
+| Catppuccin KDE | Catppuccin Mocha theme for KDE Plasma and Kvantum | install |
+| Catppuccin Terminals | Apply Catppuccin Mocha colors to kitty, WezTerm, and Alacritty | config |
+| Catppuccin Neovim | Apply Catppuccin Mocha colorscheme to Neovim | config |
+| Catppuccin tmux | Apply Catppuccin Mocha theme to tmux via TPM | config |
+| Catppuccin Hyprland | Apply Catppuccin Mocha to Hyprland, Waybar, and Wofi | config |
+
+## Quick Start
+
+```bash
+ninjamenu
+# Navigate to: Toolsets -> Terminals / Dev Tools / Theming
+```
+
+## Requirements
+
+- Debian-based Linux (Kali, Debian, Ubuntu)
+- Root/sudo access for terminal and dev-tool installs
+- Theming scripts run as current user (no root needed)
+
+## Documentation
+
+- [User Guide](../../.docs/user_manuals/toolsets.md)
+- [Technical Manual](../../.docs/technical_manuals/toolsets.md)
+
+## Tags
+
+`terminal` `gpu-accelerated` `developer` `cli` `theming` `catppuccin`

--- a/mainmenu/toolsets/category.yaml
+++ b/mainmenu/toolsets/category.yaml
@@ -1,0 +1,2 @@
+name: "Toolsets"
+description: "Developer toolsets, terminal emulators, and theming"

--- a/mainmenu/toolsets/dev-tools/bat.meta.yaml
+++ b/mainmenu/toolsets/dev-tools/bat.meta.yaml
@@ -1,0 +1,20 @@
+name: "bat"
+description: "Cat clone with syntax highlighting and Git integration"
+version: "1.0.0"
+author: "System"
+type: install
+root: true
+order: 60
+hidden: false
+installed: false
+check_command: "batcat --version"
+check_path: "/usr/bin/batcat"
+dependencies:
+  - apt
+tags:
+  - developer
+  - cli
+supported_os:
+  - kali
+  - debian
+  - ubuntu

--- a/mainmenu/toolsets/dev-tools/bat.sh
+++ b/mainmenu/toolsets/dev-tools/bat.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT_NAME="$(basename "${BASH_SOURCE[0]}" .sh)"
+MENU_ROOT="${MENU_ROOT:-$(cd "$SCRIPT_DIR" && while [[ ! -f "install_menu.sh" ]] && [[ "$PWD" != "/" ]]; do cd ..; done; pwd)}"
+source "$MENU_ROOT/.lib/platform.sh"
+
+LOG_DIR="$MENU_ROOT/.docs/logs"
+mkdir -p "$LOG_DIR"
+LOG_FILE="$LOG_DIR/${SCRIPT_NAME}_$(date +%Y%m%d_%H%M%S).log"
+exec > >(tee -a "$LOG_FILE") 2>&1
+
+install() {
+    log_info "Installing bat"
+    log_info "Log file: $LOG_FILE"
+    echo ""
+
+    require_root
+
+    pkg_update
+    pkg_install bat
+
+    # On Debian/Ubuntu the binary is named batcat — create a symlink for convenience
+    if command -v batcat &>/dev/null && ! command -v bat &>/dev/null; then
+        log_step "Creating symlink: batcat -> /usr/local/bin/bat"
+        ln -sf "$(which batcat)" /usr/local/bin/bat
+    fi
+
+    echo ""
+    log_success "bat installed successfully"
+    mark_installed true
+}
+
+uninstall() {
+    log_info "Uninstalling bat"
+    require_root
+
+    rm -f /usr/local/bin/bat
+    pkg_remove bat
+
+    log_success "bat uninstalled"
+    mark_installed false
+}
+
+case "${1:-install}" in
+    install) install ;;
+    uninstall) uninstall ;;
+    *) echo "Usage: $0 {install|uninstall}"; exit 1 ;;
+esac

--- a/mainmenu/toolsets/dev-tools/category.yaml
+++ b/mainmenu/toolsets/dev-tools/category.yaml
@@ -1,0 +1,2 @@
+name: "Developer Tools"
+description: "Essential CLI tools for developers"

--- a/mainmenu/toolsets/dev-tools/fd.meta.yaml
+++ b/mainmenu/toolsets/dev-tools/fd.meta.yaml
@@ -1,0 +1,20 @@
+name: "fd"
+description: "Fast and user-friendly alternative to find"
+version: "1.0.0"
+author: "System"
+type: install
+root: true
+order: 40
+hidden: false
+installed: false
+check_command: "fdfind --version"
+check_path: "/usr/bin/fdfind"
+dependencies:
+  - apt
+tags:
+  - developer
+  - cli
+supported_os:
+  - kali
+  - debian
+  - ubuntu

--- a/mainmenu/toolsets/dev-tools/fd.sh
+++ b/mainmenu/toolsets/dev-tools/fd.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT_NAME="$(basename "${BASH_SOURCE[0]}" .sh)"
+MENU_ROOT="${MENU_ROOT:-$(cd "$SCRIPT_DIR" && while [[ ! -f "install_menu.sh" ]] && [[ "$PWD" != "/" ]]; do cd ..; done; pwd)}"
+source "$MENU_ROOT/.lib/platform.sh"
+
+LOG_DIR="$MENU_ROOT/.docs/logs"
+mkdir -p "$LOG_DIR"
+LOG_FILE="$LOG_DIR/${SCRIPT_NAME}_$(date +%Y%m%d_%H%M%S).log"
+exec > >(tee -a "$LOG_FILE") 2>&1
+
+install() {
+    log_info "Installing fd (fd-find)"
+    log_info "Log file: $LOG_FILE"
+    echo ""
+
+    require_root
+
+    pkg_update
+    pkg_install fd-find
+
+    # On Debian/Ubuntu the binary is named fdfind — create a symlink for convenience
+    if command -v fdfind &>/dev/null && ! command -v fd &>/dev/null; then
+        log_step "Creating symlink: fdfind -> /usr/local/bin/fd"
+        ln -sf "$(which fdfind)" /usr/local/bin/fd
+    fi
+
+    echo ""
+    log_success "fd installed successfully"
+    mark_installed true
+}
+
+uninstall() {
+    log_info "Uninstalling fd"
+    require_root
+
+    rm -f /usr/local/bin/fd
+    pkg_remove fd-find
+
+    log_success "fd uninstalled"
+    mark_installed false
+}
+
+case "${1:-install}" in
+    install) install ;;
+    uninstall) uninstall ;;
+    *) echo "Usage: $0 {install|uninstall}"; exit 1 ;;
+esac

--- a/mainmenu/toolsets/dev-tools/fzf.meta.yaml
+++ b/mainmenu/toolsets/dev-tools/fzf.meta.yaml
@@ -1,0 +1,20 @@
+name: "fzf"
+description: "Command-line fuzzy finder for files, history, and more"
+version: "1.0.0"
+author: "System"
+type: install
+root: true
+order: 50
+hidden: false
+installed: false
+check_command: "fzf --version"
+check_path: "/usr/bin/fzf"
+dependencies:
+  - apt
+tags:
+  - developer
+  - cli
+supported_os:
+  - kali
+  - debian
+  - ubuntu

--- a/mainmenu/toolsets/dev-tools/fzf.sh
+++ b/mainmenu/toolsets/dev-tools/fzf.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT_NAME="$(basename "${BASH_SOURCE[0]}" .sh)"
+MENU_ROOT="${MENU_ROOT:-$(cd "$SCRIPT_DIR" && while [[ ! -f "install_menu.sh" ]] && [[ "$PWD" != "/" ]]; do cd ..; done; pwd)}"
+source "$MENU_ROOT/.lib/platform.sh"
+
+LOG_DIR="$MENU_ROOT/.docs/logs"
+mkdir -p "$LOG_DIR"
+LOG_FILE="$LOG_DIR/${SCRIPT_NAME}_$(date +%Y%m%d_%H%M%S).log"
+exec > >(tee -a "$LOG_FILE") 2>&1
+
+install() {
+    log_info "Installing fzf"
+    log_info "Log file: $LOG_FILE"
+    echo ""
+
+    require_root
+
+    pkg_update
+    pkg_install fzf
+
+    echo ""
+    log_success "fzf installed successfully"
+    mark_installed true
+}
+
+uninstall() {
+    log_info "Uninstalling fzf"
+    require_root
+
+    pkg_remove fzf
+
+    log_success "fzf uninstalled"
+    mark_installed false
+}
+
+case "${1:-install}" in
+    install) install ;;
+    uninstall) uninstall ;;
+    *) echo "Usage: $0 {install|uninstall}"; exit 1 ;;
+esac

--- a/mainmenu/toolsets/dev-tools/lazygit.meta.yaml
+++ b/mainmenu/toolsets/dev-tools/lazygit.meta.yaml
@@ -1,0 +1,20 @@
+name: "lazygit"
+description: "Simple terminal UI for Git commands"
+version: "1.0.0"
+author: "System"
+type: install
+root: true
+order: 70
+hidden: false
+installed: false
+check_command: "lazygit --version"
+check_path: "/usr/local/bin/lazygit"
+dependencies:
+  - curl
+tags:
+  - developer
+  - cli
+supported_os:
+  - kali
+  - debian
+  - ubuntu

--- a/mainmenu/toolsets/dev-tools/lazygit.sh
+++ b/mainmenu/toolsets/dev-tools/lazygit.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT_NAME="$(basename "${BASH_SOURCE[0]}" .sh)"
+MENU_ROOT="${MENU_ROOT:-$(cd "$SCRIPT_DIR" && while [[ ! -f "install_menu.sh" ]] && [[ "$PWD" != "/" ]]; do cd ..; done; pwd)}"
+source "$MENU_ROOT/.lib/platform.sh"
+
+LOG_DIR="$MENU_ROOT/.docs/logs"
+mkdir -p "$LOG_DIR"
+LOG_FILE="$LOG_DIR/${SCRIPT_NAME}_$(date +%Y%m%d_%H%M%S).log"
+exec > >(tee -a "$LOG_FILE") 2>&1
+
+install() {
+    log_info "Installing lazygit"
+    log_info "Log file: $LOG_FILE"
+    echo ""
+
+    require_root
+
+    log_step "Fetching latest lazygit release from GitHub..."
+    LAZYGIT_VERSION=$(curl -fsSL https://api.github.com/repos/jesseduffield/lazygit/releases/latest | grep '"tag_name"' | sed -E 's/.*"v([^"]+)".*/\1/')
+
+    if [[ -z "$LAZYGIT_VERSION" ]]; then
+        log_error "Failed to determine latest lazygit version"
+        exit 1
+    fi
+
+    log_step "Downloading lazygit v${LAZYGIT_VERSION}..."
+    curl -fsSL -o /tmp/lazygit.tar.gz "https://github.com/jesseduffield/lazygit/releases/download/v${LAZYGIT_VERSION}/lazygit_${LAZYGIT_VERSION}_Linux_x86_64.tar.gz"
+
+    log_step "Installing to /usr/local/bin..."
+    tar xzf /tmp/lazygit.tar.gz -C /tmp lazygit
+    install /tmp/lazygit /usr/local/bin/lazygit
+    rm -f /tmp/lazygit /tmp/lazygit.tar.gz
+
+    echo ""
+    log_success "lazygit v${LAZYGIT_VERSION} installed successfully"
+    mark_installed true
+}
+
+uninstall() {
+    log_info "Uninstalling lazygit"
+    require_root
+
+    rm -f /usr/local/bin/lazygit
+
+    log_success "lazygit uninstalled"
+    mark_installed false
+}
+
+case "${1:-install}" in
+    install) install ;;
+    uninstall) uninstall ;;
+    *) echo "Usage: $0 {install|uninstall}"; exit 1 ;;
+esac

--- a/mainmenu/toolsets/dev-tools/neovim.meta.yaml
+++ b/mainmenu/toolsets/dev-tools/neovim.meta.yaml
@@ -1,0 +1,20 @@
+name: "Neovim"
+description: "Hyperextensible Vim-based text editor"
+version: "1.0.0"
+author: "System"
+type: install
+root: true
+order: 10
+hidden: false
+installed: false
+check_command: "nvim --version"
+check_path: "/usr/bin/nvim"
+dependencies:
+  - apt
+tags:
+  - developer
+  - cli
+supported_os:
+  - kali
+  - debian
+  - ubuntu

--- a/mainmenu/toolsets/dev-tools/neovim.sh
+++ b/mainmenu/toolsets/dev-tools/neovim.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT_NAME="$(basename "${BASH_SOURCE[0]}" .sh)"
+MENU_ROOT="${MENU_ROOT:-$(cd "$SCRIPT_DIR" && while [[ ! -f "install_menu.sh" ]] && [[ "$PWD" != "/" ]]; do cd ..; done; pwd)}"
+source "$MENU_ROOT/.lib/platform.sh"
+
+LOG_DIR="$MENU_ROOT/.docs/logs"
+mkdir -p "$LOG_DIR"
+LOG_FILE="$LOG_DIR/${SCRIPT_NAME}_$(date +%Y%m%d_%H%M%S).log"
+exec > >(tee -a "$LOG_FILE") 2>&1
+
+install() {
+    log_info "Installing Neovim"
+    log_info "Log file: $LOG_FILE"
+    echo ""
+
+    require_root
+
+    pkg_update
+    pkg_install neovim
+
+    echo ""
+    log_success "Neovim installed successfully"
+    mark_installed true
+}
+
+uninstall() {
+    log_info "Uninstalling Neovim"
+    require_root
+
+    pkg_remove neovim
+
+    log_success "Neovim uninstalled"
+    mark_installed false
+}
+
+case "${1:-install}" in
+    install) install ;;
+    uninstall) uninstall ;;
+    *) echo "Usage: $0 {install|uninstall}"; exit 1 ;;
+esac

--- a/mainmenu/toolsets/dev-tools/ripgrep.meta.yaml
+++ b/mainmenu/toolsets/dev-tools/ripgrep.meta.yaml
@@ -1,0 +1,20 @@
+name: "ripgrep"
+description: "Blazing fast recursive grep replacement"
+version: "1.0.0"
+author: "System"
+type: install
+root: true
+order: 30
+hidden: false
+installed: false
+check_command: "rg --version"
+check_path: "/usr/bin/rg"
+dependencies:
+  - apt
+tags:
+  - developer
+  - cli
+supported_os:
+  - kali
+  - debian
+  - ubuntu

--- a/mainmenu/toolsets/dev-tools/ripgrep.sh
+++ b/mainmenu/toolsets/dev-tools/ripgrep.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT_NAME="$(basename "${BASH_SOURCE[0]}" .sh)"
+MENU_ROOT="${MENU_ROOT:-$(cd "$SCRIPT_DIR" && while [[ ! -f "install_menu.sh" ]] && [[ "$PWD" != "/" ]]; do cd ..; done; pwd)}"
+source "$MENU_ROOT/.lib/platform.sh"
+
+LOG_DIR="$MENU_ROOT/.docs/logs"
+mkdir -p "$LOG_DIR"
+LOG_FILE="$LOG_DIR/${SCRIPT_NAME}_$(date +%Y%m%d_%H%M%S).log"
+exec > >(tee -a "$LOG_FILE") 2>&1
+
+install() {
+    log_info "Installing ripgrep"
+    log_info "Log file: $LOG_FILE"
+    echo ""
+
+    require_root
+
+    pkg_update
+    pkg_install ripgrep
+
+    echo ""
+    log_success "ripgrep installed successfully"
+    mark_installed true
+}
+
+uninstall() {
+    log_info "Uninstalling ripgrep"
+    require_root
+
+    pkg_remove ripgrep
+
+    log_success "ripgrep uninstalled"
+    mark_installed false
+}
+
+case "${1:-install}" in
+    install) install ;;
+    uninstall) uninstall ;;
+    *) echo "Usage: $0 {install|uninstall}"; exit 1 ;;
+esac

--- a/mainmenu/toolsets/dev-tools/tmux.meta.yaml
+++ b/mainmenu/toolsets/dev-tools/tmux.meta.yaml
@@ -1,0 +1,20 @@
+name: "tmux"
+description: "Terminal multiplexer for managing multiple sessions"
+version: "1.0.0"
+author: "System"
+type: install
+root: true
+order: 20
+hidden: false
+installed: false
+check_command: "tmux -V"
+check_path: "/usr/bin/tmux"
+dependencies:
+  - apt
+tags:
+  - developer
+  - cli
+supported_os:
+  - kali
+  - debian
+  - ubuntu

--- a/mainmenu/toolsets/dev-tools/tmux.sh
+++ b/mainmenu/toolsets/dev-tools/tmux.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT_NAME="$(basename "${BASH_SOURCE[0]}" .sh)"
+MENU_ROOT="${MENU_ROOT:-$(cd "$SCRIPT_DIR" && while [[ ! -f "install_menu.sh" ]] && [[ "$PWD" != "/" ]]; do cd ..; done; pwd)}"
+source "$MENU_ROOT/.lib/platform.sh"
+
+LOG_DIR="$MENU_ROOT/.docs/logs"
+mkdir -p "$LOG_DIR"
+LOG_FILE="$LOG_DIR/${SCRIPT_NAME}_$(date +%Y%m%d_%H%M%S).log"
+exec > >(tee -a "$LOG_FILE") 2>&1
+
+install() {
+    log_info "Installing tmux"
+    log_info "Log file: $LOG_FILE"
+    echo ""
+
+    require_root
+
+    pkg_update
+    pkg_install tmux
+
+    echo ""
+    log_success "tmux installed successfully"
+    mark_installed true
+}
+
+uninstall() {
+    log_info "Uninstalling tmux"
+    require_root
+
+    pkg_remove tmux
+
+    log_success "tmux uninstalled"
+    mark_installed false
+}
+
+case "${1:-install}" in
+    install) install ;;
+    uninstall) uninstall ;;
+    *) echo "Usage: $0 {install|uninstall}"; exit 1 ;;
+esac

--- a/mainmenu/toolsets/terminals/alacritty.meta.yaml
+++ b/mainmenu/toolsets/terminals/alacritty.meta.yaml
@@ -1,0 +1,20 @@
+name: "Alacritty"
+description: "GPU-accelerated terminal emulator focused on simplicity and speed"
+version: "1.0.0"
+author: "System"
+type: install
+root: true
+order: 30
+hidden: false
+installed: false
+check_command: "alacritty --version"
+check_path: "/usr/bin/alacritty"
+dependencies:
+  - apt
+tags:
+  - terminal
+  - gpu-accelerated
+supported_os:
+  - kali
+  - debian
+  - ubuntu

--- a/mainmenu/toolsets/terminals/alacritty.sh
+++ b/mainmenu/toolsets/terminals/alacritty.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT_NAME="$(basename "${BASH_SOURCE[0]}" .sh)"
+MENU_ROOT="${MENU_ROOT:-$(cd "$SCRIPT_DIR" && while [[ ! -f "install_menu.sh" ]] && [[ "$PWD" != "/" ]]; do cd ..; done; pwd)}"
+source "$MENU_ROOT/.lib/platform.sh"
+
+LOG_DIR="$MENU_ROOT/.docs/logs"
+mkdir -p "$LOG_DIR"
+LOG_FILE="$LOG_DIR/${SCRIPT_NAME}_$(date +%Y%m%d_%H%M%S).log"
+exec > >(tee -a "$LOG_FILE") 2>&1
+
+install() {
+    log_info "Installing Alacritty terminal emulator"
+    log_info "Log file: $LOG_FILE"
+    echo ""
+
+    require_root
+
+    pkg_update
+    pkg_install alacritty
+
+    echo ""
+    log_success "Alacritty installed successfully"
+    mark_installed true
+}
+
+uninstall() {
+    log_info "Uninstalling Alacritty"
+    require_root
+
+    pkg_remove alacritty
+
+    log_success "Alacritty uninstalled"
+    mark_installed false
+}
+
+case "${1:-install}" in
+    install) install ;;
+    uninstall) uninstall ;;
+    *) echo "Usage: $0 {install|uninstall}"; exit 1 ;;
+esac

--- a/mainmenu/toolsets/terminals/category.yaml
+++ b/mainmenu/toolsets/terminals/category.yaml
@@ -1,0 +1,2 @@
+name: "Terminal Emulators"
+description: "GPU-accelerated terminal emulators"

--- a/mainmenu/toolsets/terminals/kitty.meta.yaml
+++ b/mainmenu/toolsets/terminals/kitty.meta.yaml
@@ -1,0 +1,20 @@
+name: "kitty"
+description: "GPU-accelerated terminal emulator with ligature support"
+version: "1.0.0"
+author: "System"
+type: install
+root: true
+order: 10
+hidden: false
+installed: false
+check_command: "kitty --version"
+check_path: "/usr/bin/kitty"
+dependencies:
+  - apt
+tags:
+  - terminal
+  - gpu-accelerated
+supported_os:
+  - kali
+  - debian
+  - ubuntu

--- a/mainmenu/toolsets/terminals/kitty.sh
+++ b/mainmenu/toolsets/terminals/kitty.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT_NAME="$(basename "${BASH_SOURCE[0]}" .sh)"
+MENU_ROOT="${MENU_ROOT:-$(cd "$SCRIPT_DIR" && while [[ ! -f "install_menu.sh" ]] && [[ "$PWD" != "/" ]]; do cd ..; done; pwd)}"
+source "$MENU_ROOT/.lib/platform.sh"
+
+LOG_DIR="$MENU_ROOT/.docs/logs"
+mkdir -p "$LOG_DIR"
+LOG_FILE="$LOG_DIR/${SCRIPT_NAME}_$(date +%Y%m%d_%H%M%S).log"
+exec > >(tee -a "$LOG_FILE") 2>&1
+
+install() {
+    log_info "Installing kitty terminal emulator"
+    log_info "Log file: $LOG_FILE"
+    echo ""
+
+    require_root
+
+    pkg_update
+    pkg_install kitty
+
+    echo ""
+    log_success "kitty installed successfully"
+    mark_installed true
+}
+
+uninstall() {
+    log_info "Uninstalling kitty"
+    require_root
+
+    pkg_remove kitty
+
+    log_success "kitty uninstalled"
+    mark_installed false
+}
+
+case "${1:-install}" in
+    install) install ;;
+    uninstall) uninstall ;;
+    *) echo "Usage: $0 {install|uninstall}"; exit 1 ;;
+esac

--- a/mainmenu/toolsets/terminals/wezterm.meta.yaml
+++ b/mainmenu/toolsets/terminals/wezterm.meta.yaml
@@ -1,0 +1,20 @@
+name: "WezTerm"
+description: "GPU-accelerated terminal emulator with multiplexer built-in"
+version: "1.0.0"
+author: "System"
+type: install
+root: true
+order: 20
+hidden: false
+installed: false
+check_command: "wezterm --version"
+check_path: "/usr/bin/wezterm"
+dependencies:
+  - curl
+tags:
+  - terminal
+  - gpu-accelerated
+supported_os:
+  - kali
+  - debian
+  - ubuntu

--- a/mainmenu/toolsets/terminals/wezterm.sh
+++ b/mainmenu/toolsets/terminals/wezterm.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT_NAME="$(basename "${BASH_SOURCE[0]}" .sh)"
+MENU_ROOT="${MENU_ROOT:-$(cd "$SCRIPT_DIR" && while [[ ! -f "install_menu.sh" ]] && [[ "$PWD" != "/" ]]; do cd ..; done; pwd)}"
+source "$MENU_ROOT/.lib/platform.sh"
+
+LOG_DIR="$MENU_ROOT/.docs/logs"
+mkdir -p "$LOG_DIR"
+LOG_FILE="$LOG_DIR/${SCRIPT_NAME}_$(date +%Y%m%d_%H%M%S).log"
+exec > >(tee -a "$LOG_FILE") 2>&1
+
+install() {
+    log_info "Installing WezTerm terminal emulator"
+    log_info "Log file: $LOG_FILE"
+    echo ""
+
+    require_root
+
+    log_step "Adding WezTerm APT repository..."
+    curl -fsSL https://apt.fury.io/wez/gpg.key | gpg --dearmor -o /usr/share/keyrings/wezterm-fury.gpg 2>/dev/null || true
+    echo "deb [signed-by=/usr/share/keyrings/wezterm-fury.gpg] https://apt.fury.io/wez/ * *" > /etc/apt/sources.list.d/wezterm.list
+
+    log_step "Installing WezTerm..."
+    pkg_update
+    apt-get install -y wezterm
+
+    echo ""
+    log_success "WezTerm installed successfully"
+    mark_installed true
+}
+
+uninstall() {
+    log_info "Uninstalling WezTerm"
+    require_root
+
+    apt-get remove -y wezterm 2>/dev/null || true
+    apt-get autoremove -y 2>/dev/null || true
+
+    rm -f /etc/apt/sources.list.d/wezterm.list
+    rm -f /usr/share/keyrings/wezterm-fury.gpg
+
+    log_success "WezTerm uninstalled"
+    mark_installed false
+}
+
+case "${1:-install}" in
+    install) install ;;
+    uninstall) uninstall ;;
+    *) echo "Usage: $0 {install|uninstall}"; exit 1 ;;
+esac

--- a/mainmenu/toolsets/theming/category.yaml
+++ b/mainmenu/toolsets/theming/category.yaml
@@ -1,0 +1,2 @@
+name: "Catppuccin Theming"
+description: "Catppuccin Mocha theme for terminals, editors, and desktop"

--- a/mainmenu/toolsets/theming/catppuccin-hyprland.meta.yaml
+++ b/mainmenu/toolsets/theming/catppuccin-hyprland.meta.yaml
@@ -1,0 +1,16 @@
+name: "Catppuccin Hyprland"
+description: "Apply Catppuccin Mocha to Hyprland, Waybar, and Wofi"
+version: "1.0.0"
+author: "System"
+type: config
+root: false
+order: 50
+hidden: false
+installed: false
+tags:
+  - theming
+  - catppuccin
+supported_os:
+  - kali
+  - debian
+  - ubuntu

--- a/mainmenu/toolsets/theming/catppuccin-hyprland.sh
+++ b/mainmenu/toolsets/theming/catppuccin-hyprland.sh
@@ -1,0 +1,162 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT_NAME="$(basename "${BASH_SOURCE[0]}" .sh)"
+MENU_ROOT="${MENU_ROOT:-$(cd "$SCRIPT_DIR" && while [[ ! -f "install_menu.sh" ]] && [[ "$PWD" != "/" ]]; do cd ..; done; pwd)}"
+source "$MENU_ROOT/.lib/platform.sh"
+
+LOG_DIR="$MENU_ROOT/.docs/logs"
+mkdir -p "$LOG_DIR"
+LOG_FILE="$LOG_DIR/${SCRIPT_NAME}_$(date +%Y%m%d_%H%M%S).log"
+exec > >(tee -a "$LOG_FILE") 2>&1
+
+install() {
+    log_info "Running: Catppuccin Mocha theme for Hyprland"
+    log_info "Log file: $LOG_FILE"
+    echo ""
+
+    # --- Hyprland color variables ---
+    log_step "Writing Catppuccin Mocha color variables for Hyprland..."
+    HYPR_DIR="$HOME/.config/hypr"
+    mkdir -p "$HYPR_DIR"
+
+    cat > "$HYPR_DIR/catppuccin-mocha.conf" <<'HYPREOF'
+# Catppuccin Mocha colors for Hyprland
+# Source this file from hyprland.conf: source = ~/.config/hypr/catppuccin-mocha.conf
+
+$rosewater = rgb(f5e0dc)
+$flamingo  = rgb(f2cdcd)
+$pink      = rgb(f5c2e7)
+$mauve     = rgb(cba6f7)
+$red       = rgb(f38ba8)
+$maroon    = rgb(eba0ac)
+$peach     = rgb(fab387)
+$yellow    = rgb(f9e2af)
+$green     = rgb(a6e3a1)
+$teal      = rgb(94e2d5)
+$sky       = rgb(89dceb)
+$sapphire  = rgb(74c7ec)
+$blue      = rgb(89b4fa)
+$lavender  = rgb(b4befe)
+$text      = rgb(cdd6f4)
+$subtext1  = rgb(bac2de)
+$subtext0  = rgb(a6adc8)
+$overlay2  = rgb(9399b2)
+$overlay1  = rgb(7f849c)
+$overlay0  = rgb(6c7086)
+$surface2  = rgb(585b70)
+$surface1  = rgb(45475a)
+$surface0  = rgb(313244)
+$base      = rgb(1e1e2e)
+$mantle    = rgb(181825)
+$crust     = rgb(11111b)
+HYPREOF
+
+    # Source from hyprland.conf if not already
+    if [[ -f "$HYPR_DIR/hyprland.conf" ]]; then
+        if ! grep -q "catppuccin-mocha" "$HYPR_DIR/hyprland.conf" 2>/dev/null; then
+            echo "source = ~/.config/hypr/catppuccin-mocha.conf" >> "$HYPR_DIR/hyprland.conf"
+        fi
+    fi
+
+    # --- Waybar CSS ---
+    log_step "Writing Catppuccin Mocha CSS for Waybar..."
+    WAYBAR_DIR="$HOME/.config/waybar"
+    mkdir -p "$WAYBAR_DIR"
+
+    cat > "$WAYBAR_DIR/catppuccin-mocha.css" <<'WAYEOF'
+/* Catppuccin Mocha palette for Waybar */
+@define-color rosewater #f5e0dc;
+@define-color flamingo  #f2cdcd;
+@define-color pink      #f5c2e7;
+@define-color mauve     #cba6f7;
+@define-color red       #f38ba8;
+@define-color maroon    #eba0ac;
+@define-color peach     #fab387;
+@define-color yellow    #f9e2af;
+@define-color green     #a6e3a1;
+@define-color teal      #94e2d5;
+@define-color sky       #89dceb;
+@define-color sapphire  #74c7ec;
+@define-color blue      #89b4fa;
+@define-color lavender  #b4befe;
+@define-color text      #cdd6f4;
+@define-color subtext1  #bac2de;
+@define-color subtext0  #a6adc8;
+@define-color overlay2  #9399b2;
+@define-color overlay1  #7f849c;
+@define-color overlay0  #6c7086;
+@define-color surface2  #585b70;
+@define-color surface1  #45475a;
+@define-color surface0  #313244;
+@define-color base      #1e1e2e;
+@define-color mantle    #181825;
+@define-color crust     #11111b;
+WAYEOF
+
+    # Import into waybar style.css
+    if [[ -f "$WAYBAR_DIR/style.css" ]]; then
+        if ! grep -q "catppuccin-mocha" "$WAYBAR_DIR/style.css" 2>/dev/null; then
+            sed -i '1i @import "catppuccin-mocha.css";' "$WAYBAR_DIR/style.css"
+        fi
+    else
+        echo '@import "catppuccin-mocha.css";' > "$WAYBAR_DIR/style.css"
+    fi
+
+    # --- Wofi CSS ---
+    log_step "Writing Catppuccin Mocha CSS for Wofi..."
+    WOFI_DIR="$HOME/.config/wofi"
+    mkdir -p "$WOFI_DIR"
+
+    cat > "$WOFI_DIR/catppuccin-mocha.css" <<'WOFIEOF'
+/* Catppuccin Mocha for Wofi */
+window {
+    background-color: #1e1e2e;
+    color: #cdd6f4;
+    border: 2px solid #cba6f7;
+    border-radius: 8px;
+}
+
+#input {
+    background-color: #313244;
+    color: #cdd6f4;
+    border: 1px solid #45475a;
+    border-radius: 4px;
+    padding: 8px;
+}
+
+#entry:selected {
+    background-color: #45475a;
+    color: #cdd6f4;
+    border-radius: 4px;
+}
+
+#entry {
+    padding: 4px 8px;
+}
+WOFIEOF
+
+    # Import into wofi style.css
+    if [[ -f "$WOFI_DIR/style.css" ]]; then
+        if ! grep -q "catppuccin-mocha" "$WOFI_DIR/style.css" 2>/dev/null; then
+            sed -i '1i @import "catppuccin-mocha.css";' "$WOFI_DIR/style.css"
+        fi
+    else
+        cp "$WOFI_DIR/catppuccin-mocha.css" "$WOFI_DIR/style.css"
+    fi
+
+    echo ""
+    log_success "Catppuccin Mocha applied to Hyprland, Waybar, and Wofi"
+    log_info "Reload Hyprland to see changes (hyprctl reload)"
+}
+
+uninstall() {
+    log_info "This is a config/utility script - nothing to uninstall"
+}
+
+case "${1:-install}" in
+    install) install ;;
+    uninstall) uninstall ;;
+    *) echo "Usage: $0 {install|uninstall}"; exit 1 ;;
+esac

--- a/mainmenu/toolsets/theming/catppuccin-kde/_common.sh
+++ b/mainmenu/toolsets/theming/catppuccin-kde/_common.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# Shared functions for catppuccin-kde — sourced by all OS scripts.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MENU_ROOT="${MENU_ROOT:-$(cd "$SCRIPT_DIR" && while [[ ! -f "install_menu.sh" ]] && [[ "$PWD" != "/" ]]; do cd ..; done; pwd)}"
+
+source "$MENU_ROOT/.lib/platform.sh"
+
+LOG_DIR="$MENU_ROOT/.docs/logs"
+SCRIPT_NAME="$(basename "$SCRIPT_DIR")"
+mkdir -p "$LOG_DIR"
+LOG_FILE="$LOG_DIR/${SCRIPT_NAME}_$(date +%Y%m%d_%H%M%S).log"
+
+CATPPUCCIN_KDE_REPO="https://github.com/catppuccin/kde.git"
+CATPPUCCIN_KDE_DIR="/tmp/catppuccin-kde"

--- a/mainmenu/toolsets/theming/catppuccin-kde/linux.sh
+++ b/mainmenu/toolsets/theming/catppuccin-kde/linux.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+# Linux implementation — do NOT add YAML headers here (use meta.yaml)
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/_common.sh"
+exec > >(tee -a "$LOG_FILE") 2>&1
+
+require_linux "Catppuccin KDE theme requires Linux"
+
+install() {
+    log_info "Installing Catppuccin Mocha theme for KDE..."
+    log_info "Log file: $LOG_FILE"
+    echo ""
+
+    log_step "Installing Kvantum theme engine..."
+    if command -v apt-get &>/dev/null; then
+        sudo apt-get install -y qt5-style-kvantum qt5-style-kvantum-themes 2>/dev/null || \
+            sudo apt-get install -y kvantum 2>/dev/null || true
+    fi
+
+    log_step "Cloning Catppuccin KDE theme..."
+    rm -rf "$CATPPUCCIN_KDE_DIR"
+    git clone --depth 1 "$CATPPUCCIN_KDE_REPO" "$CATPPUCCIN_KDE_DIR"
+
+    log_step "Installing color scheme..."
+    mkdir -p "$HOME/.local/share/color-schemes"
+    if [[ -d "$CATPPUCCIN_KDE_DIR/Resources/color-schemes" ]]; then
+        cp -r "$CATPPUCCIN_KDE_DIR/Resources/color-schemes/"*Mocha* "$HOME/.local/share/color-schemes/" 2>/dev/null || true
+    fi
+
+    log_step "Installing Kvantum theme..."
+    mkdir -p "$HOME/.config/Kvantum"
+    if [[ -d "$CATPPUCCIN_KDE_DIR/Resources/Kvantum" ]]; then
+        cp -r "$CATPPUCCIN_KDE_DIR/Resources/Kvantum/"*Mocha* "$HOME/.config/Kvantum/" 2>/dev/null || true
+    fi
+
+    # Clean up
+    rm -rf "$CATPPUCCIN_KDE_DIR"
+
+    echo ""
+    log_success "Catppuccin KDE theme installed"
+    log_info "Apply the theme via System Settings -> Appearance -> Colors"
+    log_info "For Kvantum: run kvantummanager and select CatppuccinMocha"
+    mark_installed true
+}
+
+uninstall() {
+    log_info "Removing Catppuccin KDE theme..."
+
+    rm -rf "$HOME/.local/share/color-schemes/"Catppuccin*Mocha*
+    rm -rf "$HOME/.config/Kvantum/"*Mocha*
+
+    log_success "Catppuccin KDE theme removed"
+    mark_installed false
+}
+
+ACTION="${1:-install}"
+case "$ACTION" in
+    install) install ;;
+    uninstall) uninstall ;;
+    *) echo "Usage: $0 {install|uninstall}"; exit 1 ;;
+esac

--- a/mainmenu/toolsets/theming/catppuccin-kde/meta.yaml
+++ b/mainmenu/toolsets/theming/catppuccin-kde/meta.yaml
@@ -1,0 +1,19 @@
+name: "Catppuccin KDE"
+description: "Catppuccin Mocha theme for KDE Plasma and Kvantum"
+version: "1.0.0"
+author: "System"
+type: install
+root: false
+order: 10
+hidden: false
+installed: false
+check_command: "test -d $HOME/.local/share/color-schemes/Catppuccin*"
+dependencies:
+  - git
+tags:
+  - theming
+  - catppuccin
+supported_os:
+  - kali
+  - debian
+  - ubuntu

--- a/mainmenu/toolsets/theming/catppuccin-neovim.meta.yaml
+++ b/mainmenu/toolsets/theming/catppuccin-neovim.meta.yaml
@@ -1,0 +1,16 @@
+name: "Catppuccin Neovim"
+description: "Apply Catppuccin Mocha colorscheme to Neovim"
+version: "1.0.0"
+author: "System"
+type: config
+root: false
+order: 30
+hidden: false
+installed: false
+tags:
+  - theming
+  - catppuccin
+supported_os:
+  - kali
+  - debian
+  - ubuntu

--- a/mainmenu/toolsets/theming/catppuccin-neovim.sh
+++ b/mainmenu/toolsets/theming/catppuccin-neovim.sh
@@ -1,0 +1,93 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT_NAME="$(basename "${BASH_SOURCE[0]}" .sh)"
+MENU_ROOT="${MENU_ROOT:-$(cd "$SCRIPT_DIR" && while [[ ! -f "install_menu.sh" ]] && [[ "$PWD" != "/" ]]; do cd ..; done; pwd)}"
+source "$MENU_ROOT/.lib/platform.sh"
+
+LOG_DIR="$MENU_ROOT/.docs/logs"
+mkdir -p "$LOG_DIR"
+LOG_FILE="$LOG_DIR/${SCRIPT_NAME}_$(date +%Y%m%d_%H%M%S).log"
+exec > >(tee -a "$LOG_FILE") 2>&1
+
+install() {
+    log_info "Running: Catppuccin Mocha theme for Neovim"
+    log_info "Log file: $LOG_FILE"
+    echo ""
+
+    if ! command -v nvim &>/dev/null; then
+        log_error "Neovim is not installed. Install it first from Dev Tools."
+        exit 1
+    fi
+
+    NVIM_CONFIG="$HOME/.config/nvim"
+    PLUGIN_DIR="$NVIM_CONFIG/lua/plugins"
+    mkdir -p "$PLUGIN_DIR"
+
+    # Detect plugin manager
+    if [[ -d "$HOME/.local/share/nvim/lazy" ]] || [[ -f "$NVIM_CONFIG/lua/config/lazy.lua" ]] || grep -rq "lazy" "$NVIM_CONFIG" 2>/dev/null; then
+        log_step "Detected lazy.nvim — writing plugin spec..."
+        cat > "$PLUGIN_DIR/catppuccin.lua" <<'LUAEOF'
+return {
+  "catppuccin/nvim",
+  name = "catppuccin",
+  priority = 1000,
+  config = function()
+    require("catppuccin").setup({
+      flavour = "mocha",
+      transparent_background = false,
+      integrations = {
+        treesitter = true,
+        native_lsp = { enabled = true },
+        cmp = true,
+        gitsigns = true,
+        telescope = { enabled = true },
+        mason = true,
+        which_key = true,
+      },
+    })
+    vim.cmd.colorscheme("catppuccin")
+  end,
+}
+LUAEOF
+    elif [[ -f "$NVIM_CONFIG/lua/plugins.lua" ]] && grep -q "packer" "$NVIM_CONFIG/lua/plugins.lua" 2>/dev/null; then
+        log_step "Detected packer.nvim — writing plugin spec..."
+        cat > "$PLUGIN_DIR/catppuccin.lua" <<'LUAEOF'
+-- Add to your packer config:
+-- use { "catppuccin/nvim", as = "catppuccin" }
+require("catppuccin").setup({ flavour = "mocha" })
+vim.cmd.colorscheme("catppuccin")
+LUAEOF
+    else
+        log_step "No plugin manager detected — writing standalone config..."
+        cat > "$PLUGIN_DIR/catppuccin.lua" <<'LUAEOF'
+-- Catppuccin Mocha for Neovim
+-- Install the plugin first: https://github.com/catppuccin/nvim
+-- For lazy.nvim, this file will be auto-loaded.
+return {
+  "catppuccin/nvim",
+  name = "catppuccin",
+  priority = 1000,
+  config = function()
+    require("catppuccin").setup({ flavour = "mocha" })
+    vim.cmd.colorscheme("catppuccin")
+  end,
+}
+LUAEOF
+    fi
+
+    echo ""
+    log_success "Catppuccin Neovim plugin config written to $PLUGIN_DIR/catppuccin.lua"
+    log_info "Restart Neovim and the plugin will be loaded"
+}
+
+uninstall() {
+    log_info "This is a config/utility script - nothing to uninstall"
+}
+
+case "${1:-install}" in
+    install) install ;;
+    uninstall) uninstall ;;
+    *) echo "Usage: $0 {install|uninstall}"; exit 1 ;;
+esac

--- a/mainmenu/toolsets/theming/catppuccin-terminals.meta.yaml
+++ b/mainmenu/toolsets/theming/catppuccin-terminals.meta.yaml
@@ -1,0 +1,16 @@
+name: "Catppuccin Terminals"
+description: "Apply Catppuccin Mocha colors to kitty, WezTerm, and Alacritty"
+version: "1.0.0"
+author: "System"
+type: config
+root: false
+order: 20
+hidden: false
+installed: false
+tags:
+  - theming
+  - catppuccin
+supported_os:
+  - kali
+  - debian
+  - ubuntu

--- a/mainmenu/toolsets/theming/catppuccin-terminals.sh
+++ b/mainmenu/toolsets/theming/catppuccin-terminals.sh
@@ -1,0 +1,209 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT_NAME="$(basename "${BASH_SOURCE[0]}" .sh)"
+MENU_ROOT="${MENU_ROOT:-$(cd "$SCRIPT_DIR" && while [[ ! -f "install_menu.sh" ]] && [[ "$PWD" != "/" ]]; do cd ..; done; pwd)}"
+source "$MENU_ROOT/.lib/platform.sh"
+
+LOG_DIR="$MENU_ROOT/.docs/logs"
+mkdir -p "$LOG_DIR"
+LOG_FILE="$LOG_DIR/${SCRIPT_NAME}_$(date +%Y%m%d_%H%M%S).log"
+exec > >(tee -a "$LOG_FILE") 2>&1
+
+install() {
+    log_info "Running: Catppuccin Mocha theme for terminal emulators"
+    log_info "Log file: $LOG_FILE"
+    echo ""
+
+    local configured=0
+
+    # --- kitty ---
+    if command -v kitty &>/dev/null; then
+        log_step "Configuring kitty..."
+        mkdir -p "$HOME/.config/kitty"
+        cat > "$HOME/.config/kitty/catppuccin-mocha.conf" <<'KITTYEOF'
+# Catppuccin Mocha for kitty
+# https://github.com/catppuccin/kitty
+
+foreground              #CDD6F4
+background              #1E1E2E
+selection_foreground    #1E1E2E
+selection_background    #F5E0DC
+
+cursor                  #F5E0DC
+cursor_text_color       #1E1E2E
+
+url_color               #F5E0DC
+
+active_tab_foreground   #11111B
+active_tab_background   #CBA6F7
+inactive_tab_foreground #CDD6F4
+inactive_tab_background #181825
+
+# black
+color0  #45475A
+color8  #585B70
+# red
+color1  #F38BA8
+color9  #F38BA8
+# green
+color2  #A6E3A1
+color10 #A6E3A1
+# yellow
+color3  #F9E2AF
+color11 #F9E2AF
+# blue
+color4  #89B4FA
+color12 #89B4FA
+# magenta
+color5  #F5C2E7
+color13 #F5C2E7
+# cyan
+color6  #94E2D5
+color14 #94E2D5
+# white
+color7  #BAC2DE
+color15 #A6ADC8
+KITTYEOF
+        # Source from main config if not already
+        if [[ -f "$HOME/.config/kitty/kitty.conf" ]]; then
+            if ! grep -q "catppuccin-mocha" "$HOME/.config/kitty/kitty.conf" 2>/dev/null; then
+                echo "include catppuccin-mocha.conf" >> "$HOME/.config/kitty/kitty.conf"
+            fi
+        else
+            echo "include catppuccin-mocha.conf" > "$HOME/.config/kitty/kitty.conf"
+        fi
+        configured=$((configured + 1))
+        log_info "kitty: catppuccin-mocha.conf written"
+    fi
+
+    # --- wezterm ---
+    if command -v wezterm &>/dev/null; then
+        log_step "Configuring WezTerm..."
+        mkdir -p "$HOME/.config/wezterm/colors"
+        cat > "$HOME/.config/wezterm/colors/catppuccin-mocha.toml" <<'WEZEOF'
+[colors]
+foreground = "#CDD6F4"
+background = "#1E1E2E"
+cursor_bg = "#F5E0DC"
+cursor_fg = "#1E1E2E"
+cursor_border = "#F5E0DC"
+selection_fg = "#1E1E2E"
+selection_bg = "#F5E0DC"
+
+ansi = ["#45475A", "#F38BA8", "#A6E3A1", "#F9E2AF", "#89B4FA", "#F5C2E7", "#94E2D5", "#BAC2DE"]
+brights = ["#585B70", "#F38BA8", "#A6E3A1", "#F9E2AF", "#89B4FA", "#F5C2E7", "#94E2D5", "#A6ADC8"]
+WEZEOF
+        configured=$((configured + 1))
+        log_info "WezTerm: catppuccin-mocha.toml written to colors directory"
+        log_info "Add 'color_scheme = \"catppuccin-mocha\"' to your wezterm.lua"
+    fi
+
+    # --- alacritty ---
+    if command -v alacritty &>/dev/null; then
+        log_step "Configuring Alacritty..."
+        mkdir -p "$HOME/.config/alacritty"
+        cat > "$HOME/.config/alacritty/catppuccin-mocha.toml" <<'ALAEOF'
+# Catppuccin Mocha for Alacritty
+# https://github.com/catppuccin/alacritty
+
+[colors.primary]
+background = "#1E1E2E"
+foreground = "#CDD6F4"
+dim_foreground = "#CDD6F4"
+bright_foreground = "#CDD6F4"
+
+[colors.cursor]
+text = "#1E1E2E"
+cursor = "#F5E0DC"
+
+[colors.vi_mode_cursor]
+text = "#1E1E2E"
+cursor = "#B4BEFE"
+
+[colors.search.matches]
+foreground = "#1E1E2E"
+background = "#A6ADC8"
+
+[colors.search.focused_match]
+foreground = "#1E1E2E"
+background = "#A6E3A1"
+
+[colors.footer_bar]
+foreground = "#1E1E2E"
+background = "#A6ADC8"
+
+[colors.hints.start]
+foreground = "#1E1E2E"
+background = "#F9E2AF"
+
+[colors.hints.end]
+foreground = "#1E1E2E"
+background = "#A6ADC8"
+
+[colors.selection]
+text = "#1E1E2E"
+background = "#F5E0DC"
+
+[colors.normal]
+black = "#45475A"
+red = "#F38BA8"
+green = "#A6E3A1"
+yellow = "#F9E2AF"
+blue = "#89B4FA"
+magenta = "#F5C2E7"
+cyan = "#94E2D5"
+white = "#BAC2DE"
+
+[colors.bright]
+black = "#585B70"
+red = "#F38BA8"
+green = "#A6E3A1"
+yellow = "#F9E2AF"
+blue = "#89B4FA"
+magenta = "#F5C2E7"
+cyan = "#94E2D5"
+white = "#A6ADC8"
+
+[colors.dim]
+black = "#45475A"
+red = "#F38BA8"
+green = "#A6E3A1"
+yellow = "#F9E2AF"
+blue = "#89B4FA"
+magenta = "#F5C2E7"
+cyan = "#94E2D5"
+white = "#BAC2DE"
+ALAEOF
+        # Import into main config if alacritty.toml exists
+        if [[ -f "$HOME/.config/alacritty/alacritty.toml" ]]; then
+            if ! grep -q "catppuccin-mocha" "$HOME/.config/alacritty/alacritty.toml" 2>/dev/null; then
+                # Prepend import directive
+                sed -i '1i import = ["~/.config/alacritty/catppuccin-mocha.toml"]' "$HOME/.config/alacritty/alacritty.toml"
+            fi
+        else
+            echo 'import = ["~/.config/alacritty/catppuccin-mocha.toml"]' > "$HOME/.config/alacritty/alacritty.toml"
+        fi
+        configured=$((configured + 1))
+        log_info "Alacritty: catppuccin-mocha.toml written and imported"
+    fi
+
+    echo ""
+    if [[ $configured -eq 0 ]]; then
+        log_info "No supported terminals found (kitty, wezterm, alacritty)"
+        log_info "Install a terminal first, then re-run this script"
+    else
+        log_success "Catppuccin Mocha applied to $configured terminal(s)"
+    fi
+}
+
+uninstall() {
+    log_info "This is a config/utility script - nothing to uninstall"
+}
+
+case "${1:-install}" in
+    install) install ;;
+    uninstall) uninstall ;;
+    *) echo "Usage: $0 {install|uninstall}"; exit 1 ;;
+esac

--- a/mainmenu/toolsets/theming/catppuccin-tmux.meta.yaml
+++ b/mainmenu/toolsets/theming/catppuccin-tmux.meta.yaml
@@ -1,0 +1,16 @@
+name: "Catppuccin tmux"
+description: "Apply Catppuccin Mocha theme to tmux via TPM"
+version: "1.0.0"
+author: "System"
+type: config
+root: false
+order: 40
+hidden: false
+installed: false
+tags:
+  - theming
+  - catppuccin
+supported_os:
+  - kali
+  - debian
+  - ubuntu

--- a/mainmenu/toolsets/theming/catppuccin-tmux.sh
+++ b/mainmenu/toolsets/theming/catppuccin-tmux.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT_NAME="$(basename "${BASH_SOURCE[0]}" .sh)"
+MENU_ROOT="${MENU_ROOT:-$(cd "$SCRIPT_DIR" && while [[ ! -f "install_menu.sh" ]] && [[ "$PWD" != "/" ]]; do cd ..; done; pwd)}"
+source "$MENU_ROOT/.lib/platform.sh"
+
+LOG_DIR="$MENU_ROOT/.docs/logs"
+mkdir -p "$LOG_DIR"
+LOG_FILE="$LOG_DIR/${SCRIPT_NAME}_$(date +%Y%m%d_%H%M%S).log"
+exec > >(tee -a "$LOG_FILE") 2>&1
+
+install() {
+    log_info "Running: Catppuccin Mocha theme for tmux"
+    log_info "Log file: $LOG_FILE"
+    echo ""
+
+    if ! command -v tmux &>/dev/null; then
+        log_error "tmux is not installed. Install it first from Dev Tools."
+        exit 1
+    fi
+
+    TPM_DIR="$HOME/.tmux/plugins/tpm"
+    TMUX_CONF="$HOME/.tmux.conf"
+
+    # Install TPM if not present
+    if [[ ! -d "$TPM_DIR" ]]; then
+        log_step "Installing tmux plugin manager (TPM)..."
+        git clone https://github.com/tmux-plugins/tpm "$TPM_DIR"
+    else
+        log_info "TPM already installed"
+    fi
+
+    # Add catppuccin plugin to tmux.conf
+    log_step "Configuring Catppuccin tmux plugin..."
+    touch "$TMUX_CONF"
+
+    if ! grep -q "catppuccin/tmux" "$TMUX_CONF" 2>/dev/null; then
+        cat >> "$TMUX_CONF" <<'TMUXEOF'
+
+# Catppuccin Mocha theme
+set -g @plugin 'catppuccin/tmux'
+set -g @catppuccin_flavour 'mocha'
+
+# TPM (keep this line at the very bottom of tmux.conf)
+set -g @plugin 'tmux-plugins/tpm'
+run '~/.tmux/plugins/tpm/tpm'
+TMUXEOF
+        log_info "Catppuccin plugin added to $TMUX_CONF"
+    else
+        log_info "Catppuccin tmux plugin already configured"
+    fi
+
+    # Ensure TPM run line exists at end
+    if ! grep -q "run.*tpm/tpm" "$TMUX_CONF" 2>/dev/null; then
+        echo "" >> "$TMUX_CONF"
+        echo "run '~/.tmux/plugins/tpm/tpm'" >> "$TMUX_CONF"
+    fi
+
+    echo ""
+    log_success "Catppuccin tmux theme configured"
+    log_info "Press prefix + I inside tmux to install the plugin via TPM"
+}
+
+uninstall() {
+    log_info "This is a config/utility script - nothing to uninstall"
+}
+
+case "${1:-install}" in
+    install) install ;;
+    uninstall) uninstall ;;
+    *) echo "Usage: $0 {install|uninstall}"; exit 1 ;;
+esac


### PR DESCRIPTION
## Summary
- Adds `mainmenu/toolsets/` with three subcategories: Terminal Emulators, Developer Tools, and Catppuccin Theming
- 3 GPU-accelerated terminals: kitty, wezterm (GPG repo), alacritty
- 7 developer CLI tools: neovim, tmux, ripgrep, fd (with fdfind symlink), fzf, bat (with batcat symlink), lazygit (GitHub release binary)
- 5 Catppuccin Mocha theming scripts: KDE (Tier 1), terminals, neovim, tmux, hyprland
- No overlap with existing `postsetup-kali/catppuccin-themes/` (that targets XFCE/GTK/ZSH/VS Code)

## Scripts Added (12)
| Script | Type | Tier | Order |
|--------|------|------|-------|
| kitty | install | 2 | 10 |
| wezterm | install | 2 | 20 |
| alacritty | install | 2 | 30 |
| neovim | install | 2 | 10 |
| tmux | install | 2 | 20 |
| ripgrep | install | 2 | 30 |
| fd | install | 2 | 40 |
| fzf | install | 2 | 50 |
| bat | install | 2 | 60 |
| lazygit | install | 2 | 70 |
| catppuccin-kde | install | 1 | 10 |
| catppuccin-terminals/neovim/tmux/hyprland | config | 2 | 20-50 |

## Test plan
- [x] `ninja-rebuild.sh` completes successfully
- [x] `menu.py --list` shows Toolsets category with all scripts
- [x] All `.sh` files are executable
- [x] All metadata files have required fields
- [ ] Do NOT execute install scripts

🤖 Generated with [Claude Code](https://claude.com/claude-code)