### PR TITLE
feat: add packages category with bundled environment profiles

### DIFF
--- a/.docs/technical_manuals/packages.md
+++ b/.docs/technical_manuals/packages.md
@@ -1,0 +1,87 @@
+# Packages - Technical Manual
+
+## Architecture
+
+Bundle scripts orchestrate the installation of multiple individual scripts from the `desktops/` and `toolsets/` categories. They follow the same pattern as `security-bundle.sh` — looping through a list of script paths, tracking success/failure, and uninstalling in reverse order.
+
+Bundles use `$MENU_ROOT`-based paths to reference scripts across categories, making them location-independent.
+
+## Scripts Reference
+
+### desktop-workstation.sh
+
+**Purpose:** Installs KDE Plasma desktop with Neovim, tmux, and Catppuccin theming
+
+**Location:** `mainmenu/packages/profiles/desktop-workstation.sh`
+
+**Bundle contents (in order):**
+1. `desktops/environments/kde-plasma/linux.sh` — KDE Plasma desktop
+2. `toolsets/dev-tools/neovim.sh` — Neovim editor
+3. `toolsets/dev-tools/tmux.sh` — Terminal multiplexer
+4. `toolsets/theming/catppuccin-kde/linux.sh` — KDE Catppuccin theme
+5. `toolsets/theming/catppuccin-neovim.sh` — Neovim Catppuccin colors
+6. `toolsets/theming/catppuccin-tmux.sh` — tmux Catppuccin plugin
+
+**Functions:**
+- `install()` — Iterates scripts, tracks SUCCEEDED/FAILED arrays, reports summary
+- `uninstall()` — Iterates scripts in reverse order
+
+**Log Output:** `.docs/logs/desktop-workstation_YYYYMMDD_HHMMSS.log`
+
+### developer-focused.sh
+
+**Purpose:** Installs Hyprland tiling WM with kitty, full dev toolchain, and Catppuccin theming
+
+**Location:** `mainmenu/packages/profiles/developer-focused.sh`
+
+**Bundle contents (in order):**
+1. `desktops/environments/hyprland/linux.sh` — Hyprland compositor
+2. `toolsets/terminals/kitty.sh` — kitty terminal
+3. `toolsets/dev-tools/neovim.sh` — Neovim editor
+4. `toolsets/dev-tools/tmux.sh` — Terminal multiplexer
+5. `toolsets/dev-tools/ripgrep.sh` — Fast grep
+6. `toolsets/dev-tools/fd.sh` — Fast find
+7. `toolsets/dev-tools/fzf.sh` — Fuzzy finder
+8. `toolsets/dev-tools/bat.sh` — Cat with syntax highlighting
+9. `toolsets/dev-tools/lazygit.sh` — Git TUI
+10. `toolsets/theming/catppuccin-terminals.sh` — Terminal colors
+11. `toolsets/theming/catppuccin-neovim.sh` — Neovim colors
+12. `toolsets/theming/catppuccin-tmux.sh` — tmux theme
+13. `toolsets/theming/catppuccin-hyprland.sh` — Hyprland/waybar/wofi theme
+
+**Functions:**
+- `install()` — Iterates scripts, tracks SUCCEEDED/FAILED arrays, reports summary
+- `uninstall()` — Iterates scripts in reverse order
+
+**Log Output:** `.docs/logs/developer-focused_YYYYMMDD_HHMMSS.log`
+
+## Integration Points
+
+### Cross-Category References
+
+Bundles reference scripts using `$MENU_ROOT`-relative paths:
+- `$MENU_ROOT/mainmenu/desktops/...` — Desktop environment scripts
+- `$MENU_ROOT/mainmenu/toolsets/...` — Terminal, dev tool, and theming scripts
+
+### Error Handling
+
+- Each script is run with `bash "$path" install`
+- Failures are caught and logged but do not stop the bundle
+- Summary shows SUCCEEDED and FAILED arrays at completion
+
+## Development
+
+### Adding a New Bundle
+
+1. Create `mainmenu/packages/profiles/<name>.sh` from the existing bundle pattern
+2. Create `mainmenu/packages/profiles/<name>.meta.yaml` with required fields
+3. Define the `SCRIPTS` array with `$MENU_ROOT`-relative paths
+4. Test with `bash mainmenu/packages/profiles/<name>.sh install`
+
+## Changelog
+
+- **v1.0.0** — Initial implementation with desktop-workstation and developer-focused profiles
+
+## See Also
+
+- [User Guide](../user_manuals/packages.md)

--- a/.docs/user_manuals/packages.md
+++ b/.docs/user_manuals/packages.md
@@ -1,0 +1,68 @@
+# Packages - User Guide
+
+## Overview
+
+Packages provides pre-configured environment bundles that install a complete desktop setup in one step. Instead of installing individual tools, choose a profile that matches your workflow and get everything configured with consistent Catppuccin theming.
+
+## Available Profiles
+
+### Desktop Workstation
+
+**What it does:** Installs a full KDE Plasma desktop with essential development tools and Catppuccin Mocha theming applied everywhere.
+
+**Includes:**
+- KDE Plasma desktop environment with SDDM
+- Neovim text editor
+- tmux terminal multiplexer
+- Catppuccin Mocha theme for KDE, Neovim, and tmux
+
+**How to use:**
+1. Run `ninjamenu`
+2. Navigate to Packages → Environment Profiles → Desktop Workstation
+3. Select Install and wait for all components to complete
+4. Reboot to start using KDE Plasma
+
+### Developer Focused
+
+**What it does:** Installs a Hyprland tiling window manager with a complete developer toolchain and Catppuccin theming.
+
+**Includes:**
+- Hyprland tiling compositor with waybar and wofi
+- kitty GPU-accelerated terminal
+- Neovim, tmux, ripgrep, fd, fzf, bat, lazygit
+- Catppuccin Mocha theme for terminals, Neovim, tmux, and Hyprland
+
+**How to use:**
+1. Run `ninjamenu`
+2. Navigate to Packages → Environment Profiles → Developer Focused
+3. Select Install and wait for all components to complete
+4. Log out and select the Hyprland session from your display manager
+
+## Common Tasks
+
+### Uninstalling a Bundle
+
+Each bundle can be fully uninstalled in reverse order:
+1. Navigate to the bundle in the menu
+2. Select Uninstall
+3. All components are removed in reverse installation order
+
+### Installing Individual Components
+
+If you only want specific tools from a bundle, install them individually from the Desktops or Toolsets categories instead.
+
+## Troubleshooting
+
+### A component fails during bundle install
+
+The bundle continues installing remaining components even if one fails. Check the log file for details on the failure, then install the failed component individually after fixing the issue.
+
+### Hyprland not available in package repos
+
+On older Debian/Ubuntu versions, Hyprland may not be in the default repositories. The Developer Focused bundle will report this error. See the Hyprland script output for manual installation instructions.
+
+## See Also
+
+- [Technical Manual](../technical_manuals/packages.md)
+- [Desktops User Guide](./desktops.md)
+- [Toolsets User Guide](./toolsets.md)

--- a/mainmenu/packages/README.md
+++ b/mainmenu/packages/README.md
@@ -1,0 +1,32 @@
+# Packages
+
+Bundled environment profiles that install multiple tools in a single operation. Each profile combines a desktop environment, developer tools, and Catppuccin theming into a cohesive setup.
+
+## Scripts
+
+| Script | Description | Type |
+|--------|-------------|------|
+| Desktop Workstation | KDE Plasma + Neovim + tmux + Catppuccin theming | install |
+| Developer Focused | Hyprland + kitty + full dev toolchain + Catppuccin theming | install |
+
+## Quick Start
+
+```bash
+ninjamenu
+# Navigate to: Packages -> Environment Profiles -> Desktop Workstation
+```
+
+## Documentation
+
+- [User Guide](../../.docs/user_manuals/packages.md) - How to use these bundles
+- [Technical Manual](../../.docs/technical_manuals/packages.md) - Developer documentation
+
+## Requirements
+
+- Root/sudo access
+- Debian-based Linux (Kali, Debian, Ubuntu)
+- Internet connection for package downloads
+
+## Tags
+
+`bundle` `desktop` `developer` `theming`

--- a/mainmenu/packages/category.yaml
+++ b/mainmenu/packages/category.yaml
@@ -1,0 +1,2 @@
+name: "Packages"
+description: "Bundled environment profiles that install multiple tools at once"

--- a/mainmenu/packages/profiles/category.yaml
+++ b/mainmenu/packages/profiles/category.yaml
@@ -1,0 +1,2 @@
+name: "Environment Profiles"
+description: "Pre-configured bundles of desktop, tools, and theming"

--- a/mainmenu/packages/profiles/desktop-workstation.meta.yaml
+++ b/mainmenu/packages/profiles/desktop-workstation.meta.yaml
@@ -1,0 +1,21 @@
+name: "Desktop Workstation"
+description: "KDE Plasma desktop with Neovim, tmux, and full Catppuccin theming"
+version: "1.0.0"
+author: "System"
+type: install
+root: true
+order: 10
+hidden: false
+installed: false
+check_command: "plasmashell --version && nvim --version && tmux -V"
+dependencies:
+  - apt
+tags:
+  - bundle
+  - desktop
+  - kde
+  - theming
+supported_os:
+  - kali
+  - debian
+  - ubuntu

--- a/mainmenu/packages/profiles/desktop-workstation.sh
+++ b/mainmenu/packages/profiles/desktop-workstation.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT_NAME="desktop-workstation"
+MENU_ROOT="${MENU_ROOT:-$(cd "$SCRIPT_DIR" && while [[ ! -f "install_menu.sh" ]] && [[ "$PWD" != "/" ]]; do cd ..; done; pwd)}"
+source "$MENU_ROOT/.lib/platform.sh"
+
+LOG_DIR="$MENU_ROOT/.docs/logs"
+mkdir -p "$LOG_DIR"
+LOG_FILE="$LOG_DIR/${SCRIPT_NAME}_$(date +%Y%m%d_%H%M%S).log"
+exec > >(tee -a "$LOG_FILE") 2>&1
+
+# Bundle: KDE Plasma + Neovim + tmux + Catppuccin theming
+SCRIPTS=(
+    "mainmenu/desktops/environments/kde-plasma/linux.sh"
+    "mainmenu/toolsets/dev-tools/neovim.sh"
+    "mainmenu/toolsets/dev-tools/tmux.sh"
+    "mainmenu/toolsets/theming/catppuccin-kde/linux.sh"
+    "mainmenu/toolsets/theming/catppuccin-neovim.sh"
+    "mainmenu/toolsets/theming/catppuccin-tmux.sh"
+)
+
+install() {
+    log_info "Installing Desktop Workstation bundle"
+    log_info "Log file: $LOG_FILE"
+    echo ""
+
+    require_root
+
+    local FAILED=()
+    local SUCCEEDED=()
+
+    for script in "${SCRIPTS[@]}"; do
+        local path="$MENU_ROOT/$script"
+        local name
+        name="$(basename "$script" .sh)"
+        echo ""
+        log_step "===== Installing $name ====="
+        if bash "$path" install; then
+            SUCCEEDED+=("$name")
+        else
+            log_error "Failed to install $name — continuing with remaining tools"
+            FAILED+=("$name")
+        fi
+    done
+
+    echo ""
+    echo "============================================"
+    log_success "Desktop Workstation bundle installation complete"
+    echo ""
+    log_info "Succeeded: ${SUCCEEDED[*]:-none}"
+    if [[ ${#FAILED[@]} -gt 0 ]]; then
+        log_error "Failed: ${FAILED[*]}"
+    fi
+    echo "============================================"
+
+    mark_installed true
+}
+
+uninstall() {
+    log_info "Uninstalling Desktop Workstation bundle"
+    require_root
+
+    # Uninstall in reverse order
+    local reversed=()
+    for ((i=${#SCRIPTS[@]}-1; i>=0; i--)); do
+        reversed+=("${SCRIPTS[$i]}")
+    done
+
+    for script in "${reversed[@]}"; do
+        local path="$MENU_ROOT/$script"
+        local name
+        name="$(basename "$script" .sh)"
+        echo ""
+        log_step "===== Uninstalling $name ====="
+        bash "$path" uninstall || {
+            log_error "Failed to uninstall $name — continuing"
+        }
+    done
+
+    echo ""
+    log_success "Desktop Workstation bundle uninstalled"
+    mark_installed false
+}
+
+case "${1:-install}" in
+    install) install ;;
+    uninstall) uninstall ;;
+    *) echo "Usage: $0 {install|uninstall}"; exit 1 ;;
+esac

--- a/mainmenu/packages/profiles/developer-focused.meta.yaml
+++ b/mainmenu/packages/profiles/developer-focused.meta.yaml
@@ -1,0 +1,21 @@
+name: "Developer Focused"
+description: "Hyprland tiling WM with kitty, full dev toolchain, and Catppuccin theming"
+version: "1.0.0"
+author: "System"
+type: install
+root: true
+order: 20
+hidden: false
+installed: false
+check_command: "hyprctl version && kitty --version && nvim --version"
+dependencies:
+  - apt
+tags:
+  - bundle
+  - developer
+  - hyprland
+  - theming
+supported_os:
+  - kali
+  - debian
+  - ubuntu

--- a/mainmenu/packages/profiles/developer-focused.sh
+++ b/mainmenu/packages/profiles/developer-focused.sh
@@ -1,0 +1,98 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT_NAME="developer-focused"
+MENU_ROOT="${MENU_ROOT:-$(cd "$SCRIPT_DIR" && while [[ ! -f "install_menu.sh" ]] && [[ "$PWD" != "/" ]]; do cd ..; done; pwd)}"
+source "$MENU_ROOT/.lib/platform.sh"
+
+LOG_DIR="$MENU_ROOT/.docs/logs"
+mkdir -p "$LOG_DIR"
+LOG_FILE="$LOG_DIR/${SCRIPT_NAME}_$(date +%Y%m%d_%H%M%S).log"
+exec > >(tee -a "$LOG_FILE") 2>&1
+
+# Bundle: Hyprland + kitty + full dev tools + Catppuccin theming
+SCRIPTS=(
+    "mainmenu/desktops/environments/hyprland/linux.sh"
+    "mainmenu/toolsets/terminals/kitty.sh"
+    "mainmenu/toolsets/dev-tools/neovim.sh"
+    "mainmenu/toolsets/dev-tools/tmux.sh"
+    "mainmenu/toolsets/dev-tools/ripgrep.sh"
+    "mainmenu/toolsets/dev-tools/fd.sh"
+    "mainmenu/toolsets/dev-tools/fzf.sh"
+    "mainmenu/toolsets/dev-tools/bat.sh"
+    "mainmenu/toolsets/dev-tools/lazygit.sh"
+    "mainmenu/toolsets/theming/catppuccin-terminals.sh"
+    "mainmenu/toolsets/theming/catppuccin-neovim.sh"
+    "mainmenu/toolsets/theming/catppuccin-tmux.sh"
+    "mainmenu/toolsets/theming/catppuccin-hyprland.sh"
+)
+
+install() {
+    log_info "Installing Developer Focused bundle"
+    log_info "Log file: $LOG_FILE"
+    echo ""
+
+    require_root
+
+    local FAILED=()
+    local SUCCEEDED=()
+
+    for script in "${SCRIPTS[@]}"; do
+        local path="$MENU_ROOT/$script"
+        local name
+        name="$(basename "$script" .sh)"
+        echo ""
+        log_step "===== Installing $name ====="
+        if bash "$path" install; then
+            SUCCEEDED+=("$name")
+        else
+            log_error "Failed to install $name — continuing with remaining tools"
+            FAILED+=("$name")
+        fi
+    done
+
+    echo ""
+    echo "============================================"
+    log_success "Developer Focused bundle installation complete"
+    echo ""
+    log_info "Succeeded: ${SUCCEEDED[*]:-none}"
+    if [[ ${#FAILED[@]} -gt 0 ]]; then
+        log_error "Failed: ${FAILED[*]}"
+    fi
+    echo "============================================"
+
+    mark_installed true
+}
+
+uninstall() {
+    log_info "Uninstalling Developer Focused bundle"
+    require_root
+
+    # Uninstall in reverse order
+    local reversed=()
+    for ((i=${#SCRIPTS[@]}-1; i>=0; i--)); do
+        reversed+=("${SCRIPTS[$i]}")
+    done
+
+    for script in "${reversed[@]}"; do
+        local path="$MENU_ROOT/$script"
+        local name
+        name="$(basename "$script" .sh)"
+        echo ""
+        log_step "===== Uninstalling $name ====="
+        bash "$path" uninstall || {
+            log_error "Failed to uninstall $name — continuing"
+        }
+    done
+
+    echo ""
+    log_success "Developer Focused bundle uninstalled"
+    mark_installed false
+}
+
+case "${1:-install}" in
+    install) install ;;
+    uninstall) uninstall ;;
+    *) echo "Usage: $0 {install|uninstall}"; exit 1 ;;
+esac


### PR DESCRIPTION
## Summary
- Adds `mainmenu/packages/` with two bundled environment profiles
- **Desktop Workstation**: KDE Plasma + Neovim + tmux + Catppuccin KDE/Neovim/tmux theming (6 scripts)
- **Developer Focused**: Hyprland + kitty + neovim + tmux + ripgrep + fd + fzf + bat + lazygit + Catppuccin theming (13 scripts)
- Follows `security-bundle.sh` orchestration pattern with SUCCEEDED/FAILED tracking and reverse-order uninstall
- Depends on #102 (desktops) and #103 (toolsets) being merged first

## Scripts Added (2 bundles)
| Bundle | Components | Order | Check |
|--------|-----------|-------|-------|
| Desktop Workstation | 6 scripts | 10 | `plasmashell --version && nvim --version && tmux -V` |
| Developer Focused | 13 scripts | 20 | `hyprctl version && kitty --version && nvim --version` |

## Test plan
- [x] `ninja-rebuild.sh` completes successfully
- [x] `menu.py --list` shows Packages category with both profiles
- [x] All `.sh` files are executable
- [x] All metadata files have required fields
- [ ] Do NOT execute install scripts
- [ ] Merge after #102 and #103

🤖 Generated with [Claude Code](https://claude.com/claude-code)