### PR TITLE
fix: use Debian Sid repo for Hyprland on Ubuntu (#106)

### DIFF
--- a/mainmenu/desktops/environments/hyprland/linux.sh
+++ b/mainmenu/desktops/environments/hyprland/linux.sh
@@ -43,13 +43,7 @@ install() {
         distro_id=$(. /etc/os-release && echo "$ID")
 
         case "$distro_id" in
-            ubuntu)
-                log_step "Adding Hyprland PPA for Ubuntu..."
-                pkg_install software-properties-common
-                add-apt-repository -y ppa:hyprwm/hyprland
-                pkg_update
-                ;;
-            kali|debian)
+            ubuntu|kali|debian)
                 log_step "Adding Debian Sid repo with low-priority pin for Hyprland..."
                 cat > /etc/apt/sources.list.d/debian-sid-hyprland.list <<'SIDREPO'
 # Added by ninja-toolbox for Hyprland packages


### PR DESCRIPTION
## Summary
- Removes non-existent `ppa:hyprwm/hyprland` PPA path for Ubuntu
- Ubuntu now uses the same Debian Sid repo + low-priority pinning strategy as Kali/Debian
- Single unified code path for all three distros

Closes #106

## Test plan
- [x] Ubuntu no longer attempts `add-apt-repository` with a bogus PPA
- [x] All three distros (ubuntu, kali, debian) hit the same Sid repo fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)